### PR TITLE
[backend] Spring Boot 3.4.7 및 Java 17로 마이그레이션

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,47 +1,44 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.2.6.RELEASE'
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '3.4.7'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-
-    // Spring Web
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-
-    // MyBatis (중복 버전 제거하고 가장 안정적인 2.1.2만 사용)
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.2'
-
-    // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
-    // lombok
-    compileOnly 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
-
-    // MySQL / MariaDB 드라이버 (둘 다 있던 경우 보통 하나만 선택)
-    implementation 'mysql:mysql-connector-java:8.0.33'
-    implementation 'org.mariadb.jdbc:mariadb-java-client:2.6.0'
-
-    // Spring Boot DevTools
-    runtimeOnly 'org.springframework.boot:spring-boot-devtools'
-
-    // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
 
-    // 테스트
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-    }
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     // MyBatis (중복 버전 제거하고 가장 안정적인 2.1.2만 사용)
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.2'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     // MySQL / MariaDB 드라이버 (둘 다 있던 경우 보통 하나만 선택)
     implementation 'mysql:mysql-connector-java:8.0.33'
     implementation 'org.mariadb.jdbc:mariadb-java-client:2.6.0'
@@ -36,4 +38,6 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+
+    annotationProcessor 'org.project lombok:lombok'
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,7 +22,12 @@ dependencies {
     // MyBatis (중복 버전 제거하고 가장 안정적인 2.1.2만 사용)
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.2'
 
+    // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     // MySQL / MariaDB 드라이버 (둘 다 있던 경우 보통 하나만 선택)
     implementation 'mysql:mysql-connector-java:8.0.33'
@@ -39,5 +44,4 @@ dependencies {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
 
-    annotationProcessor 'org.project lombok:lombok'
 }

--- a/backend/src/main/java/com/example/demo/entity/UserEntity.java
+++ b/backend/src/main/java/com/example/demo/entity/UserEntity.java
@@ -1,0 +1,19 @@
+package com.example.demo.entity;
+
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+    @Id
+    private long id;
+    private String firstName;
+    private String lastName;
+    private String initial;
+    private String color;
+    private String password;
+    private String email;
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
+    url: ${DB_URL:jdbc:mysql://localhost:3306/group_diary_db}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:qwe123}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 변경 내용

- Spring Boot 버전을 2.2.6 → 3.4.7로 업그레이드
- Java 버전을 11 → 17로 업그레이드 (Gradle toolchain 적용)
- MyBatis 의존성 버전 2.1.2 → 3.0.4로 업데이트
- `mysql:mysql-connector-j`를 최신 방식으로 runtimeOnly로 명시
- Lombok 설정을 compileOnly + annotationProcessor로 통합
- `UserEntity` 클래스에 `@Id` 필드 추가하여 JPA 매핑 정상화
- `application.yml`에 로컬 개발을 위한 기본 DB 연결 설정값(fallback) 추가