### PR TITLE
[frontend] refactor: userId 기반 단일 사용자 정보 조회 방식으로 수정

### DIFF
--- a/frontend/src/views/users/userInfoPage.vue
+++ b/frontend/src/views/users/userInfoPage.vue
@@ -22,7 +22,7 @@ export default {
     async fetchUserInfoData() {
       this.userId = this.$store.state.userId;
       const urls = [
-        `${BASE_URL}/users`
+        `${BASE_URL}/users?userId=${userId}`
       ];
 
       const requests = urls.map(async url => {
@@ -31,9 +31,13 @@ export default {
       });
 
       const responses = await Promise.all(requests);
-      this.userDataList = responses.flatMap(response => response.data);
+      this.userData = responses.json();
 
-      this.getUserDataById()
+      this.firstName = this.userData.firstName;
+      this.lastName = this.userData.lastName;
+      this.emailAddress = this.userData.email;
+      this.password = this.userData.password;
+      this.color = this.userData.color;
     },
 
     getUserDataById() {


### PR DESCRIPTION
### 변경 내용
- 기존에는 모든 사용자 정보를 가져온 후, 프론트엔드에서 userId로 해당 사용자를 찾아 사용했음

- 해당 방식을 API 호출 시 쿼리 파라미터로 userId를 넘기고, 서버에서 단일 사용자 정보를 반환받는 방식으로 변경

  - API 요청 URL: GET /users?userId=1

- this.userDataList.find()를 통해 사용자 정보를 필터링하던 로직 제거

- 사용자 정보 할당 로직을 간단하게 수정 (this.userData = await res.json())

