### PR TITLE
유저 정보 조회 및 수정 로직 fetchUserInfo API 모듈로 분리

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/UserController.java
+++ b/backend/src/main/java/com/example/demo/controller/UserController.java
@@ -67,27 +67,6 @@ public class UserController {
         return result;
     }
 
-    // 사용자 이름 요청
-//    @GetMapping("/users/name/{userId}")
-//    public HashMap<String, Object> requestUserName(@PathVariable(required = true) int userId) {
-//        String data = userService.requestUserName(userId);
-//
-//        HashMap<String, Object> result = new HashMap<>();
-//        result.put("result", "success");
-//        result.put("data", data);
-//        return result;
-//    }
-
-//    @GetMapping("/user/info/{userId}")
-//    public HashMap<String, Object> requestUserInfo(@PathVariable(required = true) int userId) {
-//        UserModel data = userService.requestUserInfo(userId);
-//
-//        HashMap<String, Object> result = new HashMap<>();
-//        result.put("result", "success");
-//        result.put("data", data);
-//        return result;
-//    }
-
     // 사용자 이메일 검색
     @GetMapping("/users/search/")
     public HashMap<String, Object> userEmailSearchModel(@RequestParam(defaultValue = "succ") String searchWord) {

--- a/frontend/src/components/HeaderComponent.vue
+++ b/frontend/src/components/HeaderComponent.vue
@@ -75,16 +75,11 @@ export default {
   methods: {
     ...mapActions(['fetchStoreData']),
     async fetchData() {
-      console.log(this.firstName);
       const inviteDataResponse = await fetch(`${BASE_URL}/members/invited/${this.userId}`);
-      console.log("at header", inviteDataResponse);
 
       const inviteDataJson = await inviteDataResponse.json();
       this.inviteData = inviteDataJson.data;
       this.alarmN = this.inviteData.length;
-
-
-      // console.log("inviteData: ", this.inviteData);
     },
 
     logOut() {

--- a/frontend/src/views/users/logInPage.vue
+++ b/frontend/src/views/users/logInPage.vue
@@ -26,11 +26,9 @@ export default {
           throw new Error('Network response was not ok');
         }
         const data = await response.json();
-        console.log(data);
 
         if (data && data.result === 'success'&& data.data.id) {
           alert('로그인이 완료되었습니다.');
-          console.log(JSON.stringify(data, null, 2));
 
           this.$store.commit('setUserId', data.data.id); 
           this.$store.commit('setFirstName', data.data.firstName); 

--- a/frontend/src/views/users/userInfoEditPage.vue
+++ b/frontend/src/views/users/userInfoEditPage.vue
@@ -1,46 +1,42 @@
 <script>
+import { fetchUserInfo } from '../../api/user';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export default {
-  mounted() {
-    this.fetchUserInfoData()
+  async mounted() {
+    await this.loadUserInfo();
   },
   data() {
     return {
       userId: 0,
-      userDataList: [],
-      userInfoData: null,
-
+      userData: null,
       firstName: '',
       lastName: '',
       emailAddress: '',
       password: '',
-      // initial: '',
       color: '',
       errors: {
         firstName: false,
         lastName: false,
         emailAddress: false,
         password: false,
-        // initial: false,
       }
     }
   },
   methods: {
-    async fetchUserInfoData() {
+    async loadUserInfo() {
       this.userId = this.$store.state.userId;
-        const urls = [
-        `${BASE_URL}/users`
-        ];
-
-        const requests = urls.map(async url => {
-            const res = await fetch(url);
-            return res.json();
-        });
-
-        const responses = await Promise.all(requests);
-        this.userDataList = responses.flatMap(response => response.data);
-
-        this.getUserDataById()
+      try {
+        const userData = await fetchUserInfo(this.userId);
+        this.userData = userData;
+        this.firstName = userData.firstName;
+        this.lastName = userData.lastName;
+        this.emailAddress = userData.email;
+        this.password = userData.password;
+        this.color = userData.color;
+      } catch (error) {
+        alert('유저 정보를 불러오는데 실패했습니다.');
+      }
     },
 
     // 사용자 info 데이터 get
@@ -53,7 +49,6 @@ export default {
         this.lastName = this.userData.last_name;
         this.emailAddress = this.userData.email;
         this.password = this.userData.password;
-        // this.initial = this.userData.initial;
         this.color = this.userData.color;
       }
     },
@@ -75,11 +70,10 @@ export default {
 
       // 입력 데이터를 객체로 수집
       const userData = {
-        first_name: this.firstName,
-        last_name: this.lastName,
+        firstName: this.firstName,
+        lastName: this.lastName,
         email: this.emailAddress,
         password: this.password,
-        // initial: this.initial,
         color: this.color
       };
 

--- a/frontend/src/views/users/userInfoPage.vue
+++ b/frontend/src/views/users/userInfoPage.vue
@@ -1,60 +1,36 @@
 <script>
-const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import { fetchUserInfo } from '../../api/user';
+
 export default {
-  mounted() {
-    this.fetchUserInfoData()
+  async mounted() {
+    await this.loadUserInfo();
   },
   data() {
     return {
       userId: 0,
-      userDataList: [],
-      userInfoData: null,
-
+      userData: null,
       firstName: '',
       lastName: '',
       emailAddress: '',
       password: '',
-      // initial: '',
       color: '',
     }
   },
   methods: {
-    async fetchUserInfoData() {
+    async loadUserInfo() {
       this.userId = this.$store.state.userId;
-      const urls = [
-        `${BASE_URL}/users?userId=${userId}`
-      ];
-
-      const requests = urls.map(async url => {
-        const res = await fetch(url);
-        return res.json();
-      });
-
-      const responses = await Promise.all(requests);
-      this.userData = responses.json();
-
-      this.firstName = this.userData.firstName;
-      this.lastName = this.userData.lastName;
-      this.emailAddress = this.userData.email;
-      this.password = this.userData.password;
-      this.color = this.userData.color;
-    },
-
-    getUserDataById() {
-      this.userData = this.userDataList.find(user => user.id === this.userId);
-      console.log(this.userData);
-
-      if (this.userData) {
-        this.firstName = this.userData.first_name;
-        this.lastName = this.userData.last_name;
-        this.emailAddress = this.userData.email;
-        this.password = this.userData.password;
-        // this.initial = this.userData.initial;
-        this.color = this.userData.color;
-
+      try {
+        const userData = await fetchUserInfo(this.userId);
+        this.userData = userData;
+        this.firstName = userData.firstName;
+        this.lastName = userData.lastName;
+        this.emailAddress = userData.email;
+        this.password = userData.password;
+        this.color = userData.color;
+      } catch (error) {
+        alert('유저 정보를 불러오는데 실패했습니다.');
       }
     },
-
     moveToEditPage() {
       this.$router.push({ path: 'userInfoEdit' });
     }


### PR DESCRIPTION
- 기존 사용자 정보 조회 및 수정 로직 중복 제거를 위해 fetchUserInfo API 모듈로 분리
- userInfo, userInfoEdit 컴포넌트에서 공통적으로 사용하는 데이터 fetch 방식 개선
- 로그인, 회원정보 수정 시 store 상태를 일관되게 관리하도록 개선
- 오타 수정 (e.g., `edite` → `edit`)
- 리팩토링된 코드에서 API 호출 실패 시 사용자에게 알림 제공