### PR TITLE
[backend] fix: CORS 설정 및 userEmailSearchModel 쿼리 수정

### DIFF
--- a/backend/src/main/java/com/example/demo/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/example/demo/config/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.demo.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -17,7 +18,8 @@ public class WebSecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable);
+        http.cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable);
 
 
         return http.build();

--- a/backend/src/main/resources/mapper/user.xml
+++ b/backend/src/main/resources/mapper/user.xml
@@ -35,7 +35,7 @@
     </delete>
 
     <select id="userEmailSearchModel" resultType="com.example.demo.user.UserModel">
-        SELECT id, first_name, last_name, email
+        SELECT id, first_name AS firstName, last_name AS lastName, email
         FROM users
         WHERE email LIKE #{likeSearchWord};
     </select>


### PR DESCRIPTION
### 주요 변경 사항

1. CORS 오류 해결을 위한 설정 보완
   - `WebSecurityConfig`에서 `.cors(Customizer.withDefaults())` 추가
   - 로컬 및 배포 환경에서 CORS 관련 preflight 오류 해결

2. userEmailSearchModel 쿼리 수정
   - MyBatis XML의 `userEmailSearchModel`에서 `first_name`, `last_name` 컬럼에 `AS` 별칭 추가
   - `UserModel` 클래스의 필드명과 일치시키기 위함