### PR TITLE
[backend] refactor: 초대/조회 관련 로직 계층 분리 및 구조 개선

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/controller/MemberController.java
@@ -85,8 +85,8 @@ public class MemberController {
 
     // 사용자가 초대된 팀 리스트 요청
     @GetMapping("/members/invited/{userId}")
-    public HashMap<String, Object> requestInvitedList(@PathVariable(required = true) int userId) {
-        List<InvitedListResponse> data = memberServiceImpl.requestInvitedList(userId);
+    public HashMap<String, Object> requestInvitedList(@PathVariable(required = true) long userId) {
+        List<InvitedListResponse> data = memberService.requestInvitedList(userId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");

--- a/backend/src/main/java/com/example/demo/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/controller/MemberController.java
@@ -3,7 +3,6 @@ package com.example.demo.controller;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
 import com.example.demo.service.MemberService;
-import com.example.demo.service.MemberServiceImpl;
 import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
@@ -20,7 +19,6 @@ import java.util.List;
 @Slf4j
 public class MemberController {
 
-    private final MemberServiceImpl memberServiceImpl;
     private final MemberService memberService;
 
     // 팀에 멤버로 초대
@@ -97,7 +95,7 @@ public class MemberController {
     // 사용자가 멤버인 팀 리스트 요청
     @GetMapping("/members/userTeamList/{userId}")
     public HashMap<String, Object> requestUserTeamList(@PathVariable(required = true) int userId) {
-        List<TeamRequest> data = memberServiceImpl.requestUserTeamList(userId);
+        List<TeamRequest> data = memberService.requestUserTeamList(userId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");

--- a/backend/src/main/java/com/example/demo/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.example.demo.controller;
 
-import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
 import com.example.demo.service.MemberService;
@@ -32,14 +31,14 @@ public class MemberController {
         return ResponseEntity.ok("멤버 초대 완료");
     }
 
-    // 팀에 멤버를 초대
-    @PostMapping("/members/{teamId}")
-    public ResponseEntity<String> requestInviteMember(@PathVariable(required = true) int teamId, @RequestBody MemberInviteInTeamRequestDTO member) {
-        member.setTeamId(teamId);
-        memberService.inviteInTeam(member);
-
-        return ResponseEntity.ok("Member invited to the team" + teamId);
-    }
+//    // 팀에 멤버를 초대
+//    @PostMapping("/members/{teamId}")
+//    public ResponseEntity<String> requestInviteMember(@PathVariable(required = true) int teamId, @RequestBody MemberInviteInTeamRequestDTO member) {
+//        member.setTeamId(teamId);
+//        memberService.inviteInTeam(member);
+//
+//        return ResponseEntity.ok("Member invited to the team" + teamId);
+//    }
 
 //    // 모든 팀의 멤버 리스트 조회
 //    @GetMapping("/members")
@@ -75,8 +74,8 @@ public class MemberController {
 
     // 팀에 속한 모든 멤버의 이름 요청
     @GetMapping("/members/{teamId}")
-    public HashMap<String, Object> requestTeamMembersName(@PathVariable(required = true) int teamId) {
-        List<TeamMembersNameResponse> data = memberServiceImpl.requestTeamMembersName(teamId);
+    public HashMap<String, Object> requestTeamMembersName(@PathVariable(required = true) long teamId) {
+        List<TeamMembersNameResponse> data = memberService.requestTeamMembersName(teamId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");

--- a/backend/src/main/java/com/example/demo/member/MemberMapper.java
+++ b/backend/src/main/java/com/example/demo/member/MemberMapper.java
@@ -28,6 +28,6 @@ public interface MemberMapper {
 
     List<InvitedListResponse> requestInvitedList(long userId);  // 사용자가 초대된 팀 리스트 요청
 
-    List<TeamRequest> requestUserTeamList(int userId);  // 사용자가 멤버인 팀 리스트 요청
+    List<TeamRequest> requestUserTeamList(long userId);  // 사용자가 멤버인 팀 리스트 요청
 
 }

--- a/backend/src/main/java/com/example/demo/member/MemberMapper.java
+++ b/backend/src/main/java/com/example/demo/member/MemberMapper.java
@@ -22,7 +22,7 @@ public interface MemberMapper {
 
     void deleteMember(long memberId);    // 멤버 삭제
 
-    List<TeamMembersNameResponse> requestTeamMembersName(int teamId);  // 팀의 모든 멤버 이름 요청
+    List<TeamMembersNameResponse> requestTeamMembersName(long teamId);  // 팀의 모든 멤버 이름 요청
 
     void requestInviteMember(MemberInviteInTeamRequestDTO member);   // 팀에 멤버를 초대
 

--- a/backend/src/main/java/com/example/demo/member/MemberMapper.java
+++ b/backend/src/main/java/com/example/demo/member/MemberMapper.java
@@ -26,7 +26,7 @@ public interface MemberMapper {
 
     void requestInviteMember(MemberInviteInTeamRequestDTO member);   // 팀에 멤버를 초대
 
-    List<InvitedListResponse> requestInvitedList(int userId);  // 사용자가 초대된 팀 리스트 요청
+    List<InvitedListResponse> requestInvitedList(long userId);  // 사용자가 초대된 팀 리스트 요청
 
     List<TeamRequest> requestUserTeamList(int userId);  // 사용자가 멤버인 팀 리스트 요청
 

--- a/backend/src/main/java/com/example/demo/repository/MemberRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/MemberRepository.java
@@ -4,6 +4,7 @@ package com.example.demo.repository;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
+import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
 
 import java.util.List;
@@ -18,4 +19,5 @@ public interface MemberRepository {
     void deleteMember(long id);
 
     List<TeamMembersNameResponse> requestTeamMembersName(long teamId);
+    List<InvitedListResponse> requestInvitedList(long userId);
 }

--- a/backend/src/main/java/com/example/demo/repository/MemberRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/MemberRepository.java
@@ -4,10 +4,18 @@ package com.example.demo.repository;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
+import com.example.demo.response.TeamMembersNameResponse;
+
+import java.util.List;
 
 public interface MemberRepository {
     void inviteMember(MemberInviteRequestDTO memberInviteRequestDTO);
+
     void inviteInTeam(MemberInviteInTeamRequestDTO memberInviteInTeamRequestDTO);
+
     void updateMember(MemberUpdateRequestDTO memberUpdateRequestDTO);
+
     void deleteMember(long id);
+
+    List<TeamMembersNameResponse> requestTeamMembersName(long teamId);
 }

--- a/backend/src/main/java/com/example/demo/repository/MemberRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/MemberRepository.java
@@ -4,6 +4,7 @@ package com.example.demo.repository;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
+import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
 
@@ -19,5 +20,8 @@ public interface MemberRepository {
     void deleteMember(long id);
 
     List<TeamMembersNameResponse> requestTeamMembersName(long teamId);
+
     List<InvitedListResponse> requestInvitedList(long userId);
+
+    List<TeamRequest> requestUserTeamList(long userId);
 }

--- a/backend/src/main/java/com/example/demo/repository/MemberRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/MemberRepositoryImplMybatis.java
@@ -4,15 +4,19 @@ import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
 import com.example.demo.member.MemberMapper;
+import com.example.demo.response.TeamMembersNameResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class MemberRepositoryImplMybatis implements MemberRepository {
     private final MemberMapper memberMapper;
+
     @Override
     public void inviteMember(MemberInviteRequestDTO memberInviteRequestDTO) {
         memberMapper.insertMember(memberInviteRequestDTO);
@@ -31,5 +35,10 @@ public class MemberRepositoryImplMybatis implements MemberRepository {
     @Override
     public void deleteMember(long id) {
         memberMapper.deleteMember(id);
+    }
+
+    @Override
+    public List<TeamMembersNameResponse> requestTeamMembersName(long teamId) {
+        return memberMapper.requestTeamMembersName(teamId);
     }
 }

--- a/backend/src/main/java/com/example/demo/repository/MemberRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/MemberRepositoryImplMybatis.java
@@ -4,6 +4,7 @@ import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
 import com.example.demo.member.MemberMapper;
+import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
 import lombok.RequiredArgsConstructor;
@@ -46,5 +47,10 @@ public class MemberRepositoryImplMybatis implements MemberRepository {
     @Override
     public List<InvitedListResponse> requestInvitedList(long userId) {
         return memberMapper.requestInvitedList(userId);
+    }
+
+    @Override
+    public List<TeamRequest> requestUserTeamList(long userId) {
+        return memberMapper.requestUserTeamList(userId);
     }
 }

--- a/backend/src/main/java/com/example/demo/repository/MemberRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/MemberRepositoryImplMybatis.java
@@ -4,6 +4,7 @@ import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
 import com.example.demo.member.MemberMapper;
+import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,5 +41,10 @@ public class MemberRepositoryImplMybatis implements MemberRepository {
     @Override
     public List<TeamMembersNameResponse> requestTeamMembersName(long teamId) {
         return memberMapper.requestTeamMembersName(teamId);
+    }
+
+    @Override
+    public List<InvitedListResponse> requestInvitedList(long userId) {
+        return memberMapper.requestInvitedList(userId);
     }
 }

--- a/backend/src/main/java/com/example/demo/service/MemberService.java
+++ b/backend/src/main/java/com/example/demo/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.demo.service;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
+import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
 
 import java.util.List;
@@ -17,4 +18,5 @@ public interface MemberService {
     void deleteMember(long id);
 
     List<TeamMembersNameResponse> requestTeamMembersName(long teamId);
+    List<InvitedListResponse> requestInvitedList(long userId);
 }

--- a/backend/src/main/java/com/example/demo/service/MemberService.java
+++ b/backend/src/main/java/com/example/demo/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.demo.service;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
+import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
 
@@ -18,5 +19,8 @@ public interface MemberService {
     void deleteMember(long id);
 
     List<TeamMembersNameResponse> requestTeamMembersName(long teamId);
+
     List<InvitedListResponse> requestInvitedList(long userId);
+
+    List<TeamRequest> requestUserTeamList(long userId);
 }

--- a/backend/src/main/java/com/example/demo/service/MemberService.java
+++ b/backend/src/main/java/com/example/demo/service/MemberService.java
@@ -3,10 +3,18 @@ package com.example.demo.service;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
+import com.example.demo.response.TeamMembersNameResponse;
+
+import java.util.List;
 
 public interface MemberService {
     void insertMember(MemberInviteRequestDTO member);
+
     void inviteInTeam(MemberInviteInTeamRequestDTO memberInviteInTeamRequestDTO);
+
     void updateMember(MemberUpdateRequestDTO memberUpdateRequestDTO);
+
     void deleteMember(long id);
+
+    List<TeamMembersNameResponse> requestTeamMembersName(long teamId);
 }

--- a/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
@@ -3,7 +3,6 @@ package com.example.demo.service;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
-import com.example.demo.member.MemberMapper;
 import com.example.demo.repository.MemberRepository;
 import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
@@ -16,7 +15,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
-    private final MemberMapper memberMapper;
     private final MemberRepository memberRepository;
 
     // 멤버 생성 (초대)
@@ -43,34 +41,27 @@ public class MemberServiceImpl implements MemberService {
 
     }
 
+    // 팀의 모든 멤버 이름 요청
     @Override
     public List<TeamMembersNameResponse> requestTeamMembersName(long teamId) {
         return memberRepository.requestTeamMembersName(teamId);
     }
 
+    // 사용자가 초대된 팀 리스트 요청
     @Override
     public List<InvitedListResponse> requestInvitedList(long userId) {
         return memberRepository.requestInvitedList(userId);
+    }
+
+    // 사용자가 멤버인 팀 리스트 요청
+    @Override
+    public List<TeamRequest> requestUserTeamList(long userId) {
+        return memberRepository.requestUserTeamList(userId);
     }
 
 //    // 모든 팀의 멤버 리스트 조회
 //    public List<MemberModel> getMembers() {
 //        return memberMapper.selectMembers();
 //    }
-
-    // 팀의 모든 멤버 이름 요청
-    public List<TeamMembersNameResponse> requestTeamMembersName(int teamId) {
-        return memberMapper.requestTeamMembersName(teamId);
-    }
-
-    // 사용자가 초대된 팀 리스트 요청
-    public List<InvitedListResponse> requestInvitedList(int userId) {
-        return memberMapper.requestInvitedList(userId);
-    }
-
-    // 사용자가 멤버인 팀 리스트 요청
-    public List<TeamRequest> requestUserTeamList(int userId) {
-        return memberMapper.requestUserTeamList(userId);
-    }
 
 }

--- a/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
@@ -48,6 +48,11 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.requestTeamMembersName(teamId);
     }
 
+    @Override
+    public List<InvitedListResponse> requestInvitedList(long userId) {
+        return memberRepository.requestInvitedList(userId);
+    }
+
 //    // 모든 팀의 멤버 리스트 조회
 //    public List<MemberModel> getMembers() {
 //        return memberMapper.selectMembers();

--- a/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
@@ -4,7 +4,6 @@ import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
 import com.example.demo.member.MemberMapper;
-import com.example.demo.member.MemberModel;
 import com.example.demo.repository.MemberRepository;
 import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
@@ -42,6 +41,11 @@ public class MemberServiceImpl implements MemberService {
     public void deleteMember(long id) {
         memberRepository.deleteMember(id);
 
+    }
+
+    @Override
+    public List<TeamMembersNameResponse> requestTeamMembersName(long teamId) {
+        return memberRepository.requestTeamMembersName(teamId);
     }
 
 //    // 모든 팀의 멤버 리스트 조회

--- a/frontend/src/views/teams/teamPage.vue
+++ b/frontend/src/views/teams/teamPage.vue
@@ -102,15 +102,14 @@ export default {
     },
     async fetchData() {
       console.log(this.firstName);
-      // console.log(this.userId);
 
-      console.log('team: ', this.$route.query.team)
-      // this.userId = this.$store.state.userId;
+      console.log('team: ', this.$route.query.team);
+      const teamId = this.$route.query.team;
       const menuList = await Promise.all([
         { type: 'diaries', url: `${BASE_URL}/teamDiaries/diaryList/${this.$route.query.team}` },
         { type: 'teams', url: `${BASE_URL}/members/userTeamList/${this.userId}` },
-        { type: 'teamMembers', url: `${BASE_URL}/members/${this.$route.query.team}` },
-        { type: 'members', url: `${BASE_URL}/members` },
+        { type: 'teamMembers', url: `${BASE_URL}/members/${teamId}` },
+        // { type: 'members', url: `${BASE_URL}/members` },
         { type: 'users', url: `${BASE_URL}/users` },
         { type: 'invites', url: `${BASE_URL}/members/invited/${this.userId}` }
       ])
@@ -127,7 +126,8 @@ export default {
 
       this.teamData = this.dataTypeMap.get('teams')
       this.teamMembersData = this.dataTypeMap.get('teamMembers')
-      this.membersData = this.dataTypeMap.get('members')
+      console.log('teamMembersData: ', this.teamMembersData);
+      // this.membersData = this.dataTypeMap.get('members')
       this.usersData = this.dataTypeMap.get('users')
       this.inviteData = this.dataTypeMap.get('invites')
 
@@ -378,7 +378,6 @@ export default {
       this.showMemberList = !this.showMemberList
     },
     teamActiveStyle(id) {
-      console.log("team id", this.selectedTeam, id)
       if (this.selectedTeam.team_id == id) {
         return " bg-info text-white"
       }


### PR DESCRIPTION
### 🔧 작업 개요
- 팀 멤버 관련 기능(조회, 초대, 사용자 팀 목록 등)의 로직을 Controller → Service → Repository 계층으로 분리하여 구조 개선

- ServiceImpl에서 직접 MemberMapper를 호출하던 방식에서 MemberRepository를 통해 접근하도록 리팩토링

- 파라미터 타입도 int → long으로 통일하여 일관성 확보

### 📁 주요 변경사항
- MemberService, MemberRepository 인터페이스 및 구현체 수정 및 메서드 추가

- MemberController의 메서드에서 memberServiceImpl 의존성 제거

- memberMapper.xml, MemberMapper.java 메서드 시그니처 일부 수정 (int → long)

- teamPage.vue:

  - 사용하지 않는 fetch, console.log 제거

  - BASE_URL 사용 시 문자열 템플릿 리터럴 오타 수정

