### PR TITLE
refactor: 일기 작성 기능 JPA 구조로 리팩토링 및 DTO, Repository 계층 분리

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/DiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/DiaryController.java
@@ -1,10 +1,12 @@
 package com.example.demo.controller;
 
 import com.example.demo.diary.DiaryModel;
-import com.example.demo.diary.DiaryService;
+import com.example.demo.dto.DiaryWriteRequestDTO;
+import com.example.demo.service.DiaryService;
+import com.example.demo.service.DiaryServiceImpl;
 import com.example.demo.response.AllTeamDiariesResponse;
-import com.example.demo.response.DiaryDetailsResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -14,6 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DiaryController {
 
+    private final DiaryServiceImpl diaryServiceImpl;
     private final DiaryService diaryService;
 
 //    @GetMapping("/diaries") // 모든 일기 리스트 조회
@@ -27,19 +30,15 @@ public class DiaryController {
 //    }
 
     @PostMapping("/diaries")    // 일기 생성
-    public HashMap<String, String> insertDiary(@RequestBody DiaryModel diary) {
-
+    public ResponseEntity<String> insertDiary(@RequestBody DiaryWriteRequestDTO diary) {
         diaryService.insertDiary(diary);
-
-        HashMap<String, String> result = new HashMap<>();
-        result.put("result", "success");
-        return result;
+        return ResponseEntity.ok("일기 작성 완료");
     }
 
     @PutMapping("/diaries/edit/{id}")    // 일기 수정
     public HashMap<String, String> updateDiary(@PathVariable(required = true) int id, @RequestBody DiaryModel diaryData) {
 
-        diaryService.updateDiary(id, diaryData);
+        diaryServiceImpl.updateDiary(id, diaryData);
 
         HashMap<String, String> result = new HashMap<>();
         result.put("result", "success");
@@ -49,7 +48,7 @@ public class DiaryController {
     @DeleteMapping("/diaries/{id}") // 일기 삭제
     public HashMap<String, String> deleteDiary(@PathVariable(required = true) int id, @RequestParam(defaultValue = "succ") String succMsg) {
 
-        diaryService.deleteDiary(id);
+        diaryServiceImpl.deleteDiary(id);
 
         HashMap<String, String> result = new HashMap<>();
         result.put("result", succMsg);
@@ -58,7 +57,7 @@ public class DiaryController {
 
     @GetMapping("/diaries/all/{userId}")    // 사용자가 속해있는 모든 그룹의 일기 조회
     public HashMap<String, Object> requestAllTeamDiaries(@PathVariable(required = true) int userId) {
-        List<AllTeamDiariesResponse> data = diaryService.requestAllTeamDiaries(userId);
+        List<AllTeamDiariesResponse> data = diaryServiceImpl.requestAllTeamDiaries(userId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");
@@ -68,7 +67,7 @@ public class DiaryController {
 
     @GetMapping("/diaries/details/{diaryId}")   // 일기 상세 내용 요청
     public HashMap<String, Object> requestDiaryDetails(@PathVariable(required = true) int diaryId) {
-        DiaryModel data = diaryService.requestDiaryDetails(diaryId);
+        DiaryModel data = diaryServiceImpl.requestDiaryDetails(diaryId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");
@@ -79,13 +78,11 @@ public class DiaryController {
     // 다이어리 id 요청
     @GetMapping("/diaries/findDiaryId")   // 일기 상세 내용 요청
     public HashMap<String, Object> requestDiaryId(@RequestParam(defaultValue = "succ") String diaryTitle, String writtenDate, int writerId) {
-        List<DiaryModel> data = diaryService.requestDiaryId(diaryTitle, writtenDate, writerId);
+        List<DiaryModel> data = diaryServiceImpl.requestDiaryId(diaryTitle, writtenDate, writerId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");
         result.put("data", data);
         return result;
     }
-
-
 }

--- a/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
@@ -18,17 +18,6 @@ public class TeamDiaryController {
         this.teamDiaryService = teamDiaryService;
     }
 
-    // 모든 팀 일기 리스트 조회
-    @GetMapping("/teamDiaries")
-    public HashMap<String, Object> getTeamDiaries() {
-        List<TeamDiaryModel> data = teamDiaryService.getTeamDiaries();
-
-        HashMap<String, Object> result = new HashMap<>();
-        result.put("result", "success");
-        result.put("data", data);
-        return result;
-    }
-
     // 팁 일기 생성
     @PostMapping("/teamDiaries")
     public HashMap<String, String> insertTeamDiary(@RequestBody TeamDiaryModel teamDiary) {
@@ -53,7 +42,7 @@ public class TeamDiaryController {
 
     // 팀 일기 삭제 (공유 해제)
     @DeleteMapping("/teamDiaries")
-    public HashMap<String, String> deleteTeamDiary(@RequestParam(defaultValue = "succ")  int diaryId, int teamId) {
+    public HashMap<String, String> deleteTeamDiary(@RequestParam(defaultValue = "succ") int diaryId, int teamId) {
 
         teamDiaryService.deleteTeamDiary(diaryId, teamId);
         HashMap<String, String> result = new HashMap<>();
@@ -82,5 +71,4 @@ public class TeamDiaryController {
         result.put("data", data);
         return result;
     }
-
 }

--- a/backend/src/main/java/com/example/demo/diary/DiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/diary/DiaryMapper.java
@@ -1,8 +1,7 @@
 package com.example.demo.diary;
 
+import com.example.demo.dto.DiaryWriteRequestDTO;
 import com.example.demo.response.AllTeamDiariesResponse;
-import com.example.demo.response.DiaryDetailsResponse;
-import com.example.demo.team.TeamModel;
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +11,8 @@ import java.util.List;
 @Repository
 public interface DiaryMapper {
     List<DiaryModel> selectDiaries();   // 모든 일기 정보 조회
-    void insertDiary(DiaryModel diary); // 일기 생성
+
+    void insertDiary(DiaryWriteRequestDTO diary); // 일기 생성
 
     void updateDiary(DiaryModel diary); // 일기 수정
 
@@ -23,7 +23,4 @@ public interface DiaryMapper {
     DiaryModel requestDiaryDetails(int diaryId);    // 일기 상세 내용 요청
 
     List<DiaryModel> requestDiaryId(String diaryTitle, String writtenDate, int writerId);    // 일기 아이디 요청
-
-
-
 }

--- a/backend/src/main/java/com/example/demo/diary/DiaryModel.java
+++ b/backend/src/main/java/com/example/demo/diary/DiaryModel.java
@@ -1,99 +1,30 @@
 package com.example.demo.diary;
 
 import com.example.demo.team.TeamModel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class DiaryModel {
 
     // 공유할 그룹
-    int id;
-    String written_date;
-    int writer_id;
-    String diary_title;
-    String details;
+    private int id;
+    private String written_date;
+    private int writer_id;
+    private String diary_title;
+    private String details;
 
-    String first_name;
-    String last_name;
+    private String first_name;
+    private String last_name;
 
-    List<TeamModel> sharedTeamList=new ArrayList<>();
+    private List<TeamModel> sharedTeamList = new ArrayList<>();
 
-    public DiaryModel() {
-    }
-
-    public DiaryModel(int id, String written_date, int writer_id, String diary_title, String details, String first_name, String last_name, List<TeamModel> sharedTeamList) {
-        this.id = id;
-        this.written_date = written_date;
-        this.writer_id = writer_id;
-        this.diary_title = diary_title;
-        this.details = details;
-        this.first_name = first_name;
-        this.last_name = last_name;
-        this.sharedTeamList = sharedTeamList;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getWritten_date() {
-        return written_date;
-    }
-
-    public void setWritten_date(String written_date) {
-        this.written_date = written_date;
-    }
-
-    public int getWriter_id() {
-        return writer_id;
-    }
-
-    public void setWriter_id(int writer_id) {
-        this.writer_id = writer_id;
-    }
-
-    public String getDiary_title() {
-        return diary_title;
-    }
-
-    public void setDiary_title(String diary_title) {
-        this.diary_title = diary_title;
-    }
-
-    public String getDetails() {
-        return details;
-    }
-
-    public void setDetails(String details) {
-        this.details = details;
-    }
-
-    public String getFirst_name() {
-        return first_name;
-    }
-
-    public void setFirst_name(String first_name) {
-        this.first_name = first_name;
-    }
-
-    public String getLast_name() {
-        return last_name;
-    }
-
-    public void setLast_name(String last_name) {
-        this.last_name = last_name;
-    }
-
-    public List<TeamModel> getSharedTeamList() {
-        return sharedTeamList;
-    }
-
-    public void setSharedTeamList(List<TeamModel> sharedTeamList) {
-        this.sharedTeamList = sharedTeamList;
-    }
 }

--- a/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTO.java
+++ b/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTO.java
@@ -1,0 +1,36 @@
+package com.example.demo.dto;
+
+import com.example.demo.diary.DiaryModel;
+import com.example.demo.team.TeamModel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+public class DiaryWriteRequestDTO {
+    private int id;
+    private String writtenDate;
+    private int writerId;
+    private String diaryTitle;
+    private String details;
+
+    private String firstName;
+    private String lastName;
+    private List<TeamModel> sharedTeamList = new ArrayList<>();
+
+    public static DiaryWriteRequestDTO from(DiaryModel diaryModel) {
+        return DiaryWriteRequestDTO.builder()
+                .id(diaryModel.getId())
+                .writtenDate(diaryModel.getWritten_date())
+                .writerId(diaryModel.getWriter_id())
+                .diaryTitle(diaryModel.getDiary_title())
+                .details(diaryModel.getDetails())
+                .firstName(diaryModel.getFirst_name())
+                .lastName(diaryModel.getLast_name())
+                .sharedTeamList(diaryModel.getSharedTeamList())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/demo/dto/LogInRequestDTO.java
+++ b/backend/src/main/java/com/example/demo/dto/LogInRequestDTO.java
@@ -10,6 +10,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LogInRequestDTO {
-   String email;
-   String password;
+    private String email;
+    private String password;
 }

--- a/backend/src/main/java/com/example/demo/repository/DiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/DiaryRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.repository;
+
+import com.example.demo.dto.DiaryWriteRequestDTO;
+
+public interface DiaryRepository {
+    void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO);
+}

--- a/backend/src/main/java/com/example/demo/repository/DiaryRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/DiaryRepositoryImplMybatis.java
@@ -1,0 +1,17 @@
+package com.example.demo.repository;
+
+import com.example.demo.diary.DiaryMapper;
+import com.example.demo.dto.DiaryWriteRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DiaryRepositoryImplMybatis implements DiaryRepository {
+    private final DiaryMapper diaryMapper;
+
+    @Override
+    public void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO) {
+        diaryMapper.insertDiary(diaryWriteRequestDTO);
+    }
+}

--- a/backend/src/main/java/com/example/demo/service/DiaryService.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryService.java
@@ -1,0 +1,7 @@
+package com.example.demo.service;
+
+import com.example.demo.dto.DiaryWriteRequestDTO;
+
+public interface DiaryService {
+    void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO);
+}

--- a/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
@@ -1,31 +1,32 @@
-package com.example.demo.diary;
+package com.example.demo.service;
 
+import com.example.demo.diary.DiaryMapper;
+import com.example.demo.diary.DiaryModel;
+import com.example.demo.dto.DiaryWriteRequestDTO;
+import com.example.demo.repository.DiaryRepository;
 import com.example.demo.response.AllTeamDiariesResponse;
-import com.example.demo.response.DiaryDetailsResponse;
 import com.example.demo.team.TeamMapper;
-import com.example.demo.team.TeamModel;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class DiaryService {
-    private DiaryMapper diaryMapper;
-    private TeamMapper teamMapper;
-
-    public DiaryService(DiaryMapper diaryMapper,TeamMapper teamMapper) {
-        this.teamMapper=teamMapper;
-        this.diaryMapper = diaryMapper;
-    }
+@RequiredArgsConstructor
+public class DiaryServiceImpl implements DiaryService {
+    private final DiaryMapper diaryMapper;
+    private final TeamMapper teamMapper;
+    private final DiaryRepository diaryRepository;
 
     // 모든 일기 리스트 조회
     public List<DiaryModel> getDiaries() {
         return diaryMapper.selectDiaries();
     }
 
-    // 일기 생성
-    public void insertDiary(DiaryModel diary) {
-        diaryMapper.insertDiary(diary);
+    // 일기 생성(일기 작성)
+    @Override
+    public void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO) {
+        diaryRepository.insertDiary(diaryWriteRequestDTO);
     }
 
     // 일기 수정
@@ -46,7 +47,7 @@ public class DiaryService {
 
     // 선택한 다이어리 상세 정보 요청
     public DiaryModel requestDiaryDetails(int diaryId) {
-        DiaryModel diary= diaryMapper.requestDiaryDetails(diaryId);
+        DiaryModel diary = diaryMapper.requestDiaryDetails(diaryId);
         diary.setSharedTeamList(teamMapper.searchTeamByDiaryId(diaryId));
         return diary;
     }
@@ -55,7 +56,4 @@ public class DiaryService {
     public List<DiaryModel> requestDiaryId(String diaryTitle, String writtenDate, int writerId) {
         return diaryMapper.requestDiaryId(diaryTitle, writtenDate, writerId);
     }
-
-
-
 }

--- a/backend/src/main/resources/mapper/diary.xml
+++ b/backend/src/main/resources/mapper/diary.xml
@@ -6,9 +6,9 @@
         FROM diaries
     </select>
 
-    <insert id="insertDiary" parameterType="com.example.demo.diary.DiaryModel">
+    <insert id="insertDiary" parameterType="com.example.demo.dto.DiaryWriteRequestDTO">
         INSERT INTO diaries (id, written_date, writer_id,diary_title, details)
-        VALUES (#{id}, #{written_date}, #{writer_id}, #{diary_title}, #{details});
+        VALUES (#{id}, #{writtenDate}, #{writerId}, #{diaryTitle}, #{details});
     </insert>
 
     <update id="updateDiary" parameterType="com.example.demo.diary.DiaryModel">

--- a/frontend/src/views/diaries/writeDiaryPage.vue
+++ b/frontend/src/views/diaries/writeDiaryPage.vue
@@ -19,7 +19,6 @@ export default {
     }
 
     this.fetchTeamData();
-    // console.log('sharedTeamId: ', this.sharedTeamId);
   },
   components: {
     cancelModal,
@@ -29,12 +28,11 @@ export default {
   },
   data() {
     return {
-      dataList: [],
 
       diaryModel: {
         id: "",
-        written_date: "",
-        diary_title: "",
+        writtenDate: "",
+        diaryTitle: "",
         details: "",
       },
 
@@ -114,7 +112,7 @@ export default {
 
     async requestPostOrUpdateDiary() {
       // 일기 post or put
-      var requestUrl = "${BASE_URL}/diaries";
+      var requestUrl = `${BASE_URL}/diaries`;
       var method = "";
       if (this.needUpdate) {
         requestUrl += `/edit/${this.diaryModel.id}`;
@@ -125,7 +123,7 @@ export default {
 
       console.log("diaryModel: ", this.diaryModel);
 
-      this.diaryModel.writer_id = this.userId;
+      this.diaryModel.writerId = this.userId;
 
       const response = await fetch(requestUrl, {
         method: method,
@@ -138,12 +136,7 @@ export default {
       if (response.ok) {
         // 요청이 성공하면 성공 메시지 표시
         console.log(`${this.needUpdate ? "수정" : "작성"} 성공 `);
-        // if (this.needUpdate) {
-        //   this.$router.push({ name: "diaryDetail", query: { diary: this.diaryModel.id } })
-        // } else {
-        //   this.$router.push({ name: "main" })
-        //   // this.$router.go(-1);
-        // }
+
       } else {
         // 요청이 실패하면 오류 메시지 표시
         const errorData = await response.json();
@@ -165,8 +158,8 @@ export default {
     },
 
     formattedDate(diary) {
-      if (diary.written_date) {
-        const date = diary.written_date;
+      if (diary.writtenDate) {
+        const date = diary.writtenDwrate;
         return `Written Date: ${date.slice(0, 2)}-${date.slice(
           2,
           4
@@ -234,8 +227,8 @@ export default {
       try {
         const response = await fetch(
           `${BASE_URL}/diaries/findDiaryId?diaryTitle=${encodeURIComponent(
-            this.diaryModel.diary_title
-          )}&writtenDate=${this.diaryModel.written_date}&writerId=${this.userId
+            this.diaryModel.diaryTitle
+          )}&writtenDate=${this.diaryModel.writtenDate}&writerId=${this.userId
           }`,
           {
             method: "GET",
@@ -276,7 +269,7 @@ export default {
 
       try {
         // 서버로 POST 요청 보내기
-        const response = await fetch("${BASE_URL}/teamDiaries/", {
+        const response = await fetch(`${BASE_URL}/teamDiaries`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -423,22 +416,6 @@ export default {
       }
       return objCopy;
     },
-
-    async fetchData() {
-      const urls = [
-        `${BASE_URL}/diaries`,
-        `${BASE_URL}/teams`,
-        `${BASE_URL}/members`,
-      ];
-
-      const requests = urls.map(async (url) => {
-        const res = await fetch(url);
-        return res.json();
-      });
-
-      this.dataList = await Promise.all(requests);
-      console.log(this.dataList);
-    },
   },
 };
 </script>
@@ -456,13 +433,13 @@ export default {
             <!-- date picker 사용 -->
             <div class="input-group input-group-static my-3">
               <label>Date</label>
-              <input v-model="diaryModel.written_date" type="date" class="form-control" />
+              <input v-model="diaryModel.writtenDate" type="date" class="form-control" />
             </div>
 
             <div class="mb-4">
               <div class="input-group input-group-static">
                 <label>title</label>
-                <input v-model="diaryModel.diary_title" type="text" class="form-control" placeholder="제목" />
+                <input v-model="diaryModel.diaryTitle" type="text" class="form-control" placeholder="제목" />
               </div>
             </div>
             <div class="mb-4">


### PR DESCRIPTION
## 주요 변경 사항

### 🔨 Backend
- 일기 작성 기능을 Controller → Service → Repository → Mapper 계층 구조로 분리
- 기존 DiaryModel을 기반으로 한 작성 요청을 DiaryWriteRequestDTO로 전환
- DiaryService 인터페이스 도입 및 DiaryServiceImpl로 구현
- DiaryRepository, DiaryRepositoryImplMybatis 생성하여 DB 접근 분리
- DiaryMapper에서 parameterType 변경 (DiaryModel → DiaryWriteRequestDTO)
- DiaryModel 필드 camelCase로 변경 및 getter/setter 정리
- 불필요한 코드 및 중복 생성자 제거

### 💻 Frontend
- diaryModel 내부 필드명을 camelCase로 수정 (ex. `written_date` → `writtenDate`)
- diary 작성/수정 요청 시 필드명에 맞춰 API 요청 구조 수정
- `${BASE_URL}` 템플릿 리터럴 누락된 부분 수정
- 일기 아이디 조회 시 QueryParam 형식 일치하도록 수정