### PR TITLE
[backend] refactor: diary 관련 메서드 Service 계층에서 Repository 계층을 거쳐 Mapper 호출하도록 구조 변경

### DIFF
--- a/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
@@ -1,6 +1,5 @@
 package com.example.demo.service;
 
-import com.example.demo.diary.DiaryMapper;
 import com.example.demo.diary.DiaryModel;
 import com.example.demo.dto.DiaryDetailResponseDTO;
 import com.example.demo.dto.DiaryEditRequestDTO;
@@ -8,7 +7,6 @@ import com.example.demo.dto.DiaryWriteRequestDTO;
 import com.example.demo.repository.DiaryRepository;
 import com.example.demo.repository.TeamRepository;
 import com.example.demo.response.AllTeamDiariesResponse;
-import com.example.demo.team.TeamMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,15 +15,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class DiaryServiceImpl implements DiaryService {
-    private final DiaryMapper diaryMapper;
-    private final TeamMapper teamMapper;
     private final DiaryRepository diaryRepository;
     private final TeamRepository teamRepository;
-
-    // 모든 일기 리스트 조회
-    public List<DiaryModel> getDiaries() {
-        return diaryMapper.selectDiaries();
-    }
 
     // 일기 생성(일기 작성)
     @Override
@@ -52,18 +43,18 @@ public class DiaryServiceImpl implements DiaryService {
     // 일기 삭제
     @Override
     public void deleteDiary(int diaryId) {
-        diaryMapper.deleteDiary(diaryId);
+        diaryRepository.deleteDiary(diaryId);
     }
 
     // 사용자가 포함된 모든 그룹의 일기 정보 요청
     @Override
     public List<AllTeamDiariesResponse> requestAllTeamDiaries(int userId) {
-        return diaryMapper.requestAllTeamDiaries(userId);
+        return diaryRepository.requestAllTeamDiaries(userId);
     }
 
     // 일기 id 요청
     @Override
     public List<DiaryModel> requestDiaryId(String diaryTitle, String writtenDate, int writerId) {
-        return diaryMapper.requestDiaryId(diaryTitle, writtenDate, writerId);
+        return diaryRepository.requestDiaryId(diaryTitle, writtenDate, writerId);
     }
 }


### PR DESCRIPTION
## 작업 내용
- diary 관련 모든 서비스 로직을 Service 계층에서 Repository를 거쳐 Mapper를 호출하도록 구조 변경

## 구조 변경 현황
- diary ✅ (완료)
- user ✅ (완료)
- member ✅ (완료)
- team ⏳ (진행 예정)
- teamDiary ⏳ (진행 예정)
