### PR TITLE
[backend] refactor: teamDiary 도메인에서 Service 구현체 직접 참조를 인터페이스 기반 참조로 변경하기위해 Service interface 생성

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
@@ -2,8 +2,9 @@ package com.example.demo.controller;
 
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
+import com.example.demo.service.TeamDiaryService;
 import com.example.demo.teamDiary.TeamDiaryModel;
-import com.example.demo.teamDiary.TeamDiaryService;
+import com.example.demo.service.TeamDiaryServiceImpl;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -12,17 +13,17 @@ import java.util.List;
 @RestController
 public class TeamDiaryController {
 
+    private TeamDiaryServiceImpl teamDiaryServiceImpl;
     private TeamDiaryService teamDiaryService;
 
-    public TeamDiaryController(TeamDiaryService teamDiaryService) {
-        this.teamDiaryService = teamDiaryService;
+    public TeamDiaryController(TeamDiaryServiceImpl teamDiaryServiceImpl) {
+        this.teamDiaryServiceImpl = teamDiaryServiceImpl;
     }
 
     // 팁 일기 생성
     @PostMapping("/teamDiaries")
     public HashMap<String, String> insertTeamDiary(@RequestBody TeamDiaryModel teamDiary) {
-
-        teamDiaryService.insertTeamDiary(teamDiary);
+        teamDiaryServiceImpl.insertTeamDiary(teamDiary);
 
         HashMap<String, String> result = new HashMap<>();
         result.put("result", "success");
@@ -33,7 +34,7 @@ public class TeamDiaryController {
     @PutMapping("/teamDiaries/{id}")
     public HashMap<String, String> updateTeamDiary(@RequestBody TeamDiaryModel teamDiaryData, @PathVariable(required = true) int id) {
 
-        teamDiaryService.updateTeamDiary(id, teamDiaryData);
+        teamDiaryServiceImpl.updateTeamDiary(id, teamDiaryData);
 
         HashMap<String, String> result = new HashMap<>();
         result.put("result", "success");
@@ -44,7 +45,7 @@ public class TeamDiaryController {
     @DeleteMapping("/teamDiaries")
     public HashMap<String, String> deleteTeamDiary(@RequestParam(defaultValue = "succ") int diaryId, int teamId) {
 
-        teamDiaryService.deleteTeamDiary(diaryId, teamId);
+        teamDiaryServiceImpl.deleteTeamDiary(diaryId, teamId);
         HashMap<String, String> result = new HashMap<>();
         result.put("result", "success");
         return result;
@@ -53,7 +54,7 @@ public class TeamDiaryController {
     // 현재 팀에 공유된 일기 리스트 요청
     @GetMapping("/teamDiaries/diaryList/{teamId}")
     public HashMap<String, Object> requestTeamDiaryList(@PathVariable(required = true) int teamId) {
-        List<TeamDiaryListResponse> data = teamDiaryService.requestTeamDiaryList(teamId);
+        List<TeamDiaryListResponse> data = teamDiaryServiceImpl.requestTeamDiaryList(teamId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");
@@ -64,7 +65,7 @@ public class TeamDiaryController {
     // 선택한 일기가 공유된 팀들의 id, 이름 요청
     @GetMapping("/teamDiaries/sharedTeams/{diaryId}")
     public HashMap<String, Object> requestSharedTeams(@PathVariable(required = true) int diaryId) {
-        List<SharedTeamsResponse> data = teamDiaryService.requestSharedTeams(diaryId);
+        List<SharedTeamsResponse> data = teamDiaryServiceImpl.requestSharedTeams(diaryId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");

--- a/backend/src/main/java/com/example/demo/service/TeamDiaryService.java
+++ b/backend/src/main/java/com/example/demo/service/TeamDiaryService.java
@@ -1,0 +1,4 @@
+package com.example.demo.service;
+
+public interface TeamDiaryService {
+}

--- a/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
@@ -1,18 +1,18 @@
-package com.example.demo.teamDiary;
+package com.example.demo.service;
 
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
+import com.example.demo.teamDiary.TeamDiaryMapper;
+import com.example.demo.teamDiary.TeamDiaryModel;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class TeamDiaryService {
-    private TeamDiaryMapper TeamDiaryMapper;
-
-    public TeamDiaryService(TeamDiaryMapper TeamDiaryMapper){
-        this.TeamDiaryMapper = TeamDiaryMapper;
-    }
+@RequiredArgsConstructor
+public class TeamDiaryServiceImpl implements TeamDiaryService {
+    private final TeamDiaryMapper TeamDiaryMapper;
 
     // 모든 팀 일기 리스트 조회
     public List<TeamDiaryModel> getTeamDiaries() {
@@ -44,6 +44,4 @@ public class TeamDiaryService {
     public List<SharedTeamsResponse> requestSharedTeams(int diaryId) {
         return TeamDiaryMapper.requestSharedTeams(diaryId);
     }
-
-
 }


### PR DESCRIPTION
## 작업 내용
- 기존 TeamDiaryService 클래스명을 TeamDiaryServiceImpl로 변경하여 구현체 명시

- TeamDiaryService 인터페이스 생성

- TeamDiaryServiceImpl이 TeamDiaryService를 구현하도록 변경