### PR TITLE
[backend] refactor: TeamDiary 도메인 repository interface와 구현체 생성

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
@@ -5,20 +5,18 @@ import com.example.demo.response.TeamDiaryListResponse;
 import com.example.demo.service.TeamDiaryService;
 import com.example.demo.teamDiary.TeamDiaryModel;
 import com.example.demo.service.TeamDiaryServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 public class TeamDiaryController {
 
-    private TeamDiaryServiceImpl teamDiaryServiceImpl;
-    private TeamDiaryService teamDiaryService;
-
-    public TeamDiaryController(TeamDiaryServiceImpl teamDiaryServiceImpl) {
-        this.teamDiaryServiceImpl = teamDiaryServiceImpl;
-    }
+    private final TeamDiaryServiceImpl teamDiaryServiceImpl;
+    private final TeamDiaryService teamDiaryService;
 
     // 팁 일기 생성
     @PostMapping("/teamDiaries")
@@ -30,16 +28,16 @@ public class TeamDiaryController {
         return result;
     }
 
-    // 팀 일기 수정
-    @PutMapping("/teamDiaries/{id}")
-    public HashMap<String, String> updateTeamDiary(@RequestBody TeamDiaryModel teamDiaryData, @PathVariable(required = true) int id) {
-
-        teamDiaryServiceImpl.updateTeamDiary(id, teamDiaryData);
-
-        HashMap<String, String> result = new HashMap<>();
-        result.put("result", "success");
-        return result;
-    }
+//    // 팀 일기 수정
+//    @PutMapping("/teamDiaries/{id}")
+//    public HashMap<String, String> updateTeamDiary(@RequestBody TeamDiaryModel teamDiaryData, @PathVariable(required = true) int id) {
+//
+//        teamDiaryServiceImpl.updateTeamDiary(id, teamDiaryData);
+//
+//        HashMap<String, String> result = new HashMap<>();
+//        result.put("result", "success");
+//        return result;
+//    }
 
     // 팀 일기 삭제 (공유 해제)
     @DeleteMapping("/teamDiaries")

--- a/backend/src/main/java/com/example/demo/repository/TeamDiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/TeamDiaryRepository.java
@@ -1,0 +1,14 @@
+package com.example.demo.repository;
+
+import com.example.demo.response.SharedTeamsResponse;
+import com.example.demo.response.TeamDiaryListResponse;
+import com.example.demo.teamDiary.TeamDiaryModel;
+
+import java.util.List;
+
+public interface TeamDiaryRepository {
+    void insertTeamDiary(TeamDiaryModel teamDiary);
+    void deleteTeamDiary(long diaryId, long teamId);
+    List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
+    List<SharedTeamsResponse> requestSharedTeams(long diaryId);
+}

--- a/backend/src/main/java/com/example/demo/repository/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/TeamDiaryRepositoryImplMyBatis.java
@@ -1,0 +1,36 @@
+package com.example.demo.repository;
+
+import com.example.demo.response.SharedTeamsResponse;
+import com.example.demo.response.TeamDiaryListResponse;
+import com.example.demo.teamDiary.TeamDiaryMapper;
+import com.example.demo.teamDiary.TeamDiaryModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TeamDiaryRepositoryImplMyBatis implements TeamDiaryRepository {
+    private final TeamDiaryMapper teamDiaryMapper;
+    @Override
+    public void insertTeamDiary(TeamDiaryModel teamDiary) {
+        teamDiaryMapper.insertTeamDiary(teamDiary);
+    }
+
+    @Override
+    public void deleteTeamDiary(long diaryId, long teamId) {
+        teamDiaryMapper.deleteTeamDiary(diaryId, teamId);
+
+    }
+
+    @Override
+    public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
+        return teamDiaryMapper.requestTeamDiaryList(teamId);
+    }
+
+    @Override
+    public List<SharedTeamsResponse> requestSharedTeams(long diaryId) {
+        return teamDiaryMapper.requestSharedTeams(diaryId);
+    }
+}

--- a/backend/src/main/java/com/example/demo/repository/TeamRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/TeamRepositoryImplMybatis.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class TeamRepositoryImpl implements TeamRepository {
+public class TeamRepositoryImplMybatis implements TeamRepository {
     private final TeamMapper teamMapper;
 
     @Override

--- a/backend/src/main/java/com/example/demo/teamDiary/TeamDiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/teamDiary/TeamDiaryMapper.java
@@ -21,13 +21,13 @@ public interface TeamDiaryMapper {
     void updateTeamDiary(TeamDiaryModel teamDiary);
 
     // 팀 일기 삭제 (공유 해제)
-    void deleteTeamDiary(int diaryId, int teamId);
+    void deleteTeamDiary(long diaryId, long teamId);
 
     // 현재 팀에 공유된 일기 리스트 요청
-    List<TeamDiaryListResponse> requestTeamDiaryList(int teamId);
+    List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
 
     // 선택한 일기가 공유된 팀들의 id, 이름 요청
-    List<SharedTeamsResponse> requestSharedTeams(int diaryId);
+    List<SharedTeamsResponse> requestSharedTeams(long diaryId);
 
 
 


### PR DESCRIPTION
## 작업 내용
- TeamDiary 도메인 repository interface와 구현체 생성
- TeamDiary controller에서 사용하지 않는 api 주석처리
- TeamRepositoryImpl -> TeamRepositoryImplMybatis 클래스명 변경
- TeamDiary Mapper에서 모든 ID 필드 int -> long 타입 변경