### PR TITLE
[backend] refactor: TeamDiary 도메인 ID 타입 변경 및 TeamDiaryPostRequest DTO 적용

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
@@ -1,10 +1,9 @@
 package com.example.demo.controller;
 
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import com.example.demo.service.TeamDiaryService;
-import com.example.demo.teamDiary.TeamDiaryModel;
-import com.example.demo.service.TeamDiaryServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,29 +14,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TeamDiaryController {
 
-    private final TeamDiaryServiceImpl teamDiaryServiceImpl;
     private final TeamDiaryService teamDiaryService;
 
     // 팁 일기 생성
     @PostMapping("/teamDiaries")
-    public HashMap<String, String> insertTeamDiary(@RequestBody TeamDiaryModel teamDiary) {
+    public HashMap<String, String> insertTeamDiary(@RequestBody TeamDiaryPostRequestDTO teamDiary) {
         teamDiaryService.insertTeamDiary(teamDiary);
 
         HashMap<String, String> result = new HashMap<>();
         result.put("result", "success");
         return result;
     }
-
-//    // 팀 일기 수정
-//    @PutMapping("/teamDiaries/{id}")
-//    public HashMap<String, String> updateTeamDiary(@RequestBody TeamDiaryModel teamDiaryData, @PathVariable(required = true) int id) {
-//
-//        teamDiaryServiceImpl.updateTeamDiary(id, teamDiaryData);
-//
-//        HashMap<String, String> result = new HashMap<>();
-//        result.put("result", "success");
-//        return result;
-//    }
 
     // 팀 일기 삭제 (공유 해제)
     @DeleteMapping("/teamDiaries")

--- a/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
@@ -41,7 +41,7 @@ public class TeamDiaryController {
 
     // 팀 일기 삭제 (공유 해제)
     @DeleteMapping("/teamDiaries")
-    public HashMap<String, String> deleteTeamDiary(@RequestParam(defaultValue = "succ") int diaryId, int teamId) {
+    public HashMap<String, String> deleteTeamDiary(@RequestParam(defaultValue = "succ") long diaryId, long teamId) {
 
         teamDiaryService.deleteTeamDiary(diaryId, teamId);
         HashMap<String, String> result = new HashMap<>();
@@ -51,7 +51,7 @@ public class TeamDiaryController {
 
     // 현재 팀에 공유된 일기 리스트 요청
     @GetMapping("/teamDiaries/diaryList/{teamId}")
-    public HashMap<String, Object> requestTeamDiaryList(@PathVariable(required = true) int teamId) {
+    public HashMap<String, Object> requestTeamDiaryList(@PathVariable(required = true) long teamId) {
         List<TeamDiaryListResponse> data = teamDiaryService.requestTeamDiaryList(teamId);
 
         HashMap<String, Object> result = new HashMap<>();
@@ -62,7 +62,7 @@ public class TeamDiaryController {
 
     // 선택한 일기가 공유된 팀들의 id, 이름 요청
     @GetMapping("/teamDiaries/sharedTeams/{diaryId}")
-    public HashMap<String, Object> requestSharedTeams(@PathVariable(required = true) int diaryId) {
+    public HashMap<String, Object> requestSharedTeams(@PathVariable(required = true) long diaryId) {
         List<SharedTeamsResponse> data = teamDiaryService.requestSharedTeams(diaryId);
 
         HashMap<String, Object> result = new HashMap<>();

--- a/backend/src/main/java/com/example/demo/dto/TeamDiaryPostRequestDTO.java
+++ b/backend/src/main/java/com/example/demo/dto/TeamDiaryPostRequestDTO.java
@@ -1,0 +1,10 @@
+package com.example.demo.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TeamDiaryPostRequestDTO {
+    private long id;
+    private long diary_id;
+    private long team_id;
+}

--- a/backend/src/main/java/com/example/demo/repository/TeamDiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/TeamDiaryRepository.java
@@ -1,14 +1,17 @@
 package com.example.demo.repository;
 
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
-import com.example.demo.teamDiary.TeamDiaryModel;
 
 import java.util.List;
 
 public interface TeamDiaryRepository {
-    void insertTeamDiary(TeamDiaryModel teamDiary);
+    void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary);
+
     void deleteTeamDiary(long diaryId, long teamId);
+
     List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
+
     List<SharedTeamsResponse> requestSharedTeams(long diaryId);
 }

--- a/backend/src/main/java/com/example/demo/repository/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/TeamDiaryRepositoryImplMyBatis.java
@@ -1,9 +1,9 @@
 package com.example.demo.repository;
 
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import com.example.demo.teamDiary.TeamDiaryMapper;
-import com.example.demo.teamDiary.TeamDiaryModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,8 +13,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TeamDiaryRepositoryImplMyBatis implements TeamDiaryRepository {
     private final TeamDiaryMapper teamDiaryMapper;
+
     @Override
-    public void insertTeamDiary(TeamDiaryModel teamDiary) {
+    public void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary) {
         teamDiaryMapper.insertTeamDiary(teamDiary);
     }
 

--- a/backend/src/main/java/com/example/demo/service/TeamDiaryService.java
+++ b/backend/src/main/java/com/example/demo/service/TeamDiaryService.java
@@ -1,15 +1,13 @@
 package com.example.demo.service;
 
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
-import com.example.demo.teamDiary.TeamDiaryModel;
 
 import java.util.List;
 
 public interface TeamDiaryService {
-    List<TeamDiaryModel> getTeamDiaries();
-
-    void insertTeamDiary(TeamDiaryModel teamDiary);
+    void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary);
 
     void deleteTeamDiary(long diaryId, long teamId);
 

--- a/backend/src/main/java/com/example/demo/service/TeamDiaryService.java
+++ b/backend/src/main/java/com/example/demo/service/TeamDiaryService.java
@@ -11,9 +11,9 @@ public interface TeamDiaryService {
 
     void insertTeamDiary(TeamDiaryModel teamDiary);
 
-    void deleteTeamDiary(int diaryId, int teamId);
+    void deleteTeamDiary(long diaryId, long teamId);
 
-    List<TeamDiaryListResponse> requestTeamDiaryList(int teamId);
+    List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
 
-    List<SharedTeamsResponse> requestSharedTeams(int diaryId);
+    List<SharedTeamsResponse> requestSharedTeams(long diaryId);
 }

--- a/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
@@ -1,9 +1,9 @@
 package com.example.demo.service;
 
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import com.example.demo.teamDiary.TeamDiaryMapper;
-import com.example.demo.teamDiary.TeamDiaryModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,22 +14,10 @@ import java.util.List;
 public class TeamDiaryServiceImpl implements TeamDiaryService {
     private final TeamDiaryMapper TeamDiaryMapper;
 
-    // 모든 팀 일기 리스트 조회
-    @Override
-    public List<TeamDiaryModel> getTeamDiaries() {
-        return TeamDiaryMapper.selectTeamDiaries();
-    }
-
     // 팁 일기 생성
     @Override
-    public void insertTeamDiary(TeamDiaryModel teamDiary) {
+    public void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary) {
         TeamDiaryMapper.insertTeamDiary(teamDiary);
-    }
-
-    // 팀 일기 수정
-    public void updateTeamDiary(long teamDiaryId, TeamDiaryModel teamDiary) {
-        teamDiary.setId(teamDiaryId);
-        TeamDiaryMapper.updateTeamDiary(teamDiary);
     }
 
     // 팀 일기 삭제 (공유 해제)

--- a/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
@@ -27,26 +27,26 @@ public class TeamDiaryServiceImpl implements TeamDiaryService {
     }
 
     // 팀 일기 수정
-    public void updateTeamDiary(int teamDiaryId, TeamDiaryModel teamDiary) {
+    public void updateTeamDiary(long teamDiaryId, TeamDiaryModel teamDiary) {
         teamDiary.setId(teamDiaryId);
         TeamDiaryMapper.updateTeamDiary(teamDiary);
     }
 
     // 팀 일기 삭제 (공유 해제)
     @Override
-    public void deleteTeamDiary(int diaryId, int teamId) {
+    public void deleteTeamDiary(long diaryId, long teamId) {
         TeamDiaryMapper.deleteTeamDiary(diaryId, teamId);
     }
 
     // 현재 팀에 공유된 일기 리스트 요청
     @Override
-    public List<TeamDiaryListResponse> requestTeamDiaryList(int teamId) {
+    public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
         return TeamDiaryMapper.requestTeamDiaryList(teamId);
     }
 
     // 선택한 일기가 공유된 팀들의 id, 이름 요청
     @Override
-    public List<SharedTeamsResponse> requestSharedTeams(int diaryId) {
+    public List<SharedTeamsResponse> requestSharedTeams(long diaryId) {
         return TeamDiaryMapper.requestSharedTeams(diaryId);
     }
 }

--- a/backend/src/main/java/com/example/demo/teamDiary/TeamDiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/teamDiary/TeamDiaryMapper.java
@@ -1,5 +1,6 @@
 package com.example.demo.teamDiary;
 
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import org.apache.ibatis.annotations.Mapper;
@@ -11,14 +12,8 @@ import java.util.List;
 @Repository
 public interface TeamDiaryMapper {
 
-    // 모든 팀 일기 리스트 조회
-    List<TeamDiaryModel> selectTeamDiaries();
-
     // 팁 일기 생성
-    void insertTeamDiary(TeamDiaryModel teamDiary);
-
-    // 팀 일기 수정
-    void updateTeamDiary(TeamDiaryModel teamDiary);
+    void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary);
 
     // 팀 일기 삭제 (공유 해제)
     void deleteTeamDiary(long diaryId, long teamId);
@@ -28,7 +23,4 @@ public interface TeamDiaryMapper {
 
     // 선택한 일기가 공유된 팀들의 id, 이름 요청
     List<SharedTeamsResponse> requestSharedTeams(long diaryId);
-
-
-
 }

--- a/backend/src/main/java/com/example/demo/teamDiary/TeamDiaryModel.java
+++ b/backend/src/main/java/com/example/demo/teamDiary/TeamDiaryModel.java
@@ -1,7 +1,7 @@
 package com.example.demo.teamDiary;
 
 public class TeamDiaryModel {
-    int id;
+    long id;
     int diary_id;
     int team_id;
 
@@ -14,7 +14,7 @@ public class TeamDiaryModel {
         this.team_id = team_id;
     }
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 
@@ -26,7 +26,7 @@ public class TeamDiaryModel {
         return team_id;
     }
 
-    public void setId(int id) {
+    public void setId(long id) {
         this.id = id;
     }
 

--- a/backend/src/main/resources/mapper/teamDiary.xml
+++ b/backend/src/main/resources/mapper/teamDiary.xml
@@ -6,7 +6,7 @@
         FROM team_diary;
     </select>
 
-    <insert id="insertTeamDiary" parameterType="com.example.demo.teamDiary.TeamDiaryModel">
+    <insert id="insertTeamDiary" parameterType="com.example.demo.dto.TeamDiaryPostRequestDTO">
         INSERT INTO team_diary (id, diary_id, team_id)
         VALUES (#{id}, #{diary_id}, #{team_id});
     </insert>
@@ -14,28 +14,31 @@
     <update id="updateTeamDiary" parameterType="com.example.demo.teamDiary.TeamDiaryModel">
         UPDATE team_diary
         SET diary_id = #{diary_id},
-            team_id = #{team_id}
+            team_id  = #{team_id}
         WHERE id = #{id};
     </update>
 
     <delete id="deleteTeamDiary" parameterType="com.example.demo.teamDiary.TeamDiaryModel">
         DELETE
         FROM team_diary
-        WHERE diary_id = #{diaryId} AND team_id = #{teamId};
+        WHERE diary_id = #{diaryId}
+          AND team_id = #{teamId};
     </delete>
 
     <select id="requestTeamDiaryList" resultType="com.example.demo.response.TeamDiaryListResponse">
         SELECT d.id, u.first_name, u.last_name, u.initial, u.color, d.written_date, d.diary_title
-        FROM team_diary td JOIN diaries d
-           ON td.diary_id = d.id
-           JOIN users u ON d.writer_id = u.id
+        FROM team_diary td
+                 JOIN diaries d
+                      ON td.diary_id = d.id
+                 JOIN users u ON d.writer_id = u.id
         WHERE td.team_id = #{teamId};
     </select>
 
     <select id="requestSharedTeams" resultType="com.example.demo.response.SharedTeamsResponse">
         SELECT td.team_id, t.team_name
-        FROM team_diary td JOIN teams t
-            ON td.team_id = t.id
+        FROM team_diary td
+                 JOIN teams t
+                      ON td.team_id = t.id
         WHERE td.diary_id = #{diaryId};
     </select>
 </mapper>


### PR DESCRIPTION
## 변경 사항
- TeamDiary 도메인에서 ID 관련 변수 타입을 int → long으로 변경
- `TeamDiaryPostRequest` DTO 생성하고, 관련 요청 로직에 적용