### PR TITLE
[backend] refactor: 팀 ID 조회 로직에서 반환 타입을 model → DTO로 변경

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/TeamController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamController.java
@@ -1,7 +1,7 @@
 package com.example.demo.controller;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
-import com.example.demo.model.TeamModel;
+import com.example.demo.dto.TeamSearchIdResponseDTO;
 import com.example.demo.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +27,7 @@ public class TeamController {
     // 팀 id 조회
     @GetMapping("/teams/findId")
     public HashMap<String, Object> findTeamId(@RequestParam(defaultValue = "succ") String teamName, int creatorId) {
-        List<TeamModel> data = teamService.findTeamId(teamName, creatorId);
+        List<TeamSearchIdResponseDTO> data = teamService.findTeamId(teamName, creatorId);
 
         HashMap<String, Object> result = new HashMap<>();
         result.put("result", "success");

--- a/backend/src/main/java/com/example/demo/dto/TeamSearchIdResponseDTO.java
+++ b/backend/src/main/java/com/example/demo/dto/TeamSearchIdResponseDTO.java
@@ -1,0 +1,12 @@
+package com.example.demo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeamSearchIdResponseDTO {
+    private int id;
+    private String team_name;
+    private int creator_id;
+}

--- a/backend/src/main/java/com/example/demo/repository/TeamRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/TeamRepository.java
@@ -1,6 +1,7 @@
 package com.example.demo.repository;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
+import com.example.demo.dto.TeamSearchIdResponseDTO;
 import com.example.demo.model.TeamModel;
 
 import java.util.List;
@@ -10,5 +11,5 @@ public interface TeamRepository {
 
     void insertTeam(TeamCreateRequestDTO team);
 
-    List<TeamModel> findTeamId(String teamName, long creatorId);
+    List<TeamSearchIdResponseDTO> findTeamId(String teamName, long creatorId);
 }

--- a/backend/src/main/java/com/example/demo/repository/TeamRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/TeamRepositoryImplMybatis.java
@@ -1,12 +1,14 @@
 package com.example.demo.repository;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
+import com.example.demo.dto.TeamSearchIdResponseDTO;
 import com.example.demo.mapper.TeamMapper;
 import com.example.demo.model.TeamModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -24,7 +26,15 @@ public class TeamRepositoryImplMybatis implements TeamRepository {
     }
 
     @Override
-    public List<TeamModel> findTeamId(String teamName, long creatorId) {
-        return teamMapper.findTeamId(teamName, creatorId);
+    public List<TeamSearchIdResponseDTO> findTeamId(String teamName, long creatorId) {
+        List<TeamModel> teamModelList = teamMapper.findTeamId(teamName, creatorId);
+
+        return teamModelList.stream()
+                .map(teamModel -> TeamSearchIdResponseDTO.builder()
+                        .id(teamModel.getId())
+                        .team_name(teamModel.getTeam_name())
+                        .creator_id(teamModel.getCreator_id())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/example/demo/service/TeamService.java
+++ b/backend/src/main/java/com/example/demo/service/TeamService.java
@@ -1,12 +1,12 @@
 package com.example.demo.service;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
-import com.example.demo.model.TeamModel;
+import com.example.demo.dto.TeamSearchIdResponseDTO;
 
 import java.util.List;
 
 public interface TeamService {
     void insertTeam(TeamCreateRequestDTO team);
 
-    List<TeamModel> findTeamId(String teamName, long creatorId);
+    List<TeamSearchIdResponseDTO> findTeamId(String teamName, long creatorId);
 }

--- a/backend/src/main/java/com/example/demo/service/TeamServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/TeamServiceImpl.java
@@ -1,7 +1,7 @@
 package com.example.demo.service;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
-import com.example.demo.model.TeamModel;
+import com.example.demo.dto.TeamSearchIdResponseDTO;
 import com.example.demo.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +19,7 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
-    public List<TeamModel> findTeamId(String teamName, long creatorId) {
+    public List<TeamSearchIdResponseDTO> findTeamId(String teamName, long creatorId) {
         return teamRepository.findTeamId(teamName, creatorId);
     }
 


### PR DESCRIPTION
### 변경 내용
- TeamSearchIdResponseDTO 클래스 생성

- repository 계층에서 TeamModel → TeamSearchIdResponseDTO 변환 적용

- TeamRepository, TeamService, TeamServiceImpl 반환 타입 수정

- TeamController에서 DTO 기반 응답 처리로 변경

