### PR TITLE
[backend] chore: repository 디렉토리 구조를 interface와 MyBatis 구현체로 분리하여 정리

### DIFF
--- a/backend/src/main/java/com/example/demo/repository/inter/DiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/DiaryRepository.java
@@ -1,4 +1,4 @@
-package com.example.demo.repository;
+package com.example.demo.repository.inter;
 
 import com.example.demo.dto.*;
 

--- a/backend/src/main/java/com/example/demo/repository/inter/MemberRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/MemberRepository.java
@@ -1,4 +1,4 @@
-package com.example.demo.repository;
+package com.example.demo.repository.inter;
 
 
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;

--- a/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
@@ -1,4 +1,4 @@
-package com.example.demo.repository;
+package com.example.demo.repository.inter;
 
 import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;

--- a/backend/src/main/java/com/example/demo/repository/inter/TeamRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/TeamRepository.java
@@ -1,4 +1,4 @@
-package com.example.demo.repository;
+package com.example.demo.repository.inter;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
 import com.example.demo.dto.TeamSearchIdResponseDTO;

--- a/backend/src/main/java/com/example/demo/repository/inter/UserRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/UserRepository.java
@@ -1,4 +1,4 @@
-package com.example.demo.repository;
+package com.example.demo.repository.inter;
 
 import com.example.demo.dto.*;
 import com.example.demo.model.UserModel;

--- a/backend/src/main/java/com/example/demo/repository/mybatis/DiaryRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatis/DiaryRepositoryImplMybatis.java
@@ -1,8 +1,9 @@
-package com.example.demo.repository;
+package com.example.demo.repository.mybatis;
 
 import com.example.demo.dto.*;
 import com.example.demo.mapper.DiaryMapper;
 import com.example.demo.model.DiaryModel;
+import com.example.demo.repository.inter.DiaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/backend/src/main/java/com/example/demo/repository/mybatis/MemberRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatis/MemberRepositoryImplMybatis.java
@@ -1,9 +1,10 @@
-package com.example.demo.repository;
+package com.example.demo.repository.mybatis;
 
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
 import com.example.demo.mapper.MemberMapper;
+import com.example.demo.repository.inter.MemberRepository;
 import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;

--- a/backend/src/main/java/com/example/demo/repository/mybatis/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatis/TeamDiaryRepositoryImplMyBatis.java
@@ -1,6 +1,7 @@
-package com.example.demo.repository;
+package com.example.demo.repository.mybatis;
 
 import com.example.demo.dto.TeamDiaryPostRequestDTO;
+import com.example.demo.repository.inter.TeamDiaryRepository;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import com.example.demo.mapper.TeamDiaryMapper;

--- a/backend/src/main/java/com/example/demo/repository/mybatis/TeamRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatis/TeamRepositoryImplMybatis.java
@@ -1,9 +1,10 @@
-package com.example.demo.repository;
+package com.example.demo.repository.mybatis;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
 import com.example.demo.dto.TeamSearchIdResponseDTO;
 import com.example.demo.mapper.TeamMapper;
 import com.example.demo.model.TeamModel;
+import com.example.demo.repository.inter.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/backend/src/main/java/com/example/demo/repository/mybatis/UserRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatis/UserRepositoryImplMybatis.java
@@ -1,8 +1,9 @@
-package com.example.demo.repository;
+package com.example.demo.repository.mybatis;
 
 import com.example.demo.dto.*;
 import com.example.demo.mapper.UserMapper;
 import com.example.demo.model.UserModel;
+import com.example.demo.repository.inter.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
@@ -1,8 +1,8 @@
 package com.example.demo.service;
 
 import com.example.demo.dto.*;
-import com.example.demo.repository.DiaryRepository;
-import com.example.demo.repository.TeamRepository;
+import com.example.demo.repository.inter.DiaryRepository;
+import com.example.demo.repository.inter.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/MemberServiceImpl.java
@@ -3,7 +3,7 @@ package com.example.demo.service;
 import com.example.demo.dto.MemberInviteInTeamRequestDTO;
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
-import com.example.demo.repository.MemberRepository;
+import com.example.demo.repository.inter.MemberRepository;
 import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;

--- a/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/TeamDiaryServiceImpl.java
@@ -1,7 +1,7 @@
 package com.example.demo.service;
 
 import com.example.demo.dto.TeamDiaryPostRequestDTO;
-import com.example.demo.repository.TeamDiaryRepository;
+import com.example.demo.repository.inter.TeamDiaryRepository;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/example/demo/service/TeamServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/TeamServiceImpl.java
@@ -2,7 +2,7 @@ package com.example.demo.service;
 
 import com.example.demo.dto.TeamCreateRequestDTO;
 import com.example.demo.dto.TeamSearchIdResponseDTO;
-import com.example.demo.repository.TeamRepository;
+import com.example.demo.repository.inter.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/com/example/demo/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.example.demo.service;
 
 import com.example.demo.dto.*;
-import com.example.demo.repository.UserRepository;
+import com.example.demo.repository.inter.UserRepository;
 import com.example.demo.mapper.UserMapper;
 import com.example.demo.model.UserModel;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
### 변경 사항
- 기존 repository 디렉토리를 역할에 따라 두 개의 서브 디렉토리로 분리

  - repository.inter: 각 도메인별 Repository interface

  - repository.mybatis: MyBatis 기반 Repository 구현체 클래스

- ServiceImpl 클래스들에서 변경된 패키지에 맞게 의존성 수정

### 작업 목적
- 추후 JPA 기반 구현체로의 교체를 용이하게 하기 위함
