### PR TITLE
[backend] feat: repository JPA 구현체 클래스 생성 및 MyBatis 구현체에 @Primary 설정

### DIFF
--- a/backend/src/main/java/com/example/demo/jpa/UserJPARepository.java
+++ b/backend/src/main/java/com/example/demo/jpa/UserJPARepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.jpa;
+
+import com.example.demo.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserJPARepository extends JpaRepository<UserEntity, Long> {
+    UserEntity findAllByEmailAndPassword(long email, String password);
+
+}

--- a/backend/src/main/java/com/example/demo/model/TeamModel.java
+++ b/backend/src/main/java/com/example/demo/model/TeamModel.java
@@ -1,40 +1,14 @@
 package com.example.demo.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class TeamModel {
-    int id;
+    long id;
     String team_name;
-    int creator_id;
-
-    public TeamModel() {
-    }
-
-    public TeamModel(int id, String team_name, int creator_id) {
-        this.id = id;
-        this.team_name = team_name;
-        this.creator_id = creator_id;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getTeam_name() {
-        return team_name;
-    }
-
-    public void setTeam_name(String team_name) {
-        this.team_name = team_name;
-    }
-
-    public int getCreator_id() {
-        return creator_id;
-    }
-
-    public void setCreator_id(int creator_id) {
-        this.creator_id = creator_id;
-    }
+    long creator_id;
 }

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/DiaryRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/DiaryRepositoryImplJpa.java
@@ -1,0 +1,38 @@
+package com.example.demo.repository.jpaImpl;
+
+import com.example.demo.dto.*;
+import com.example.demo.repository.inter.DiaryRepository;
+
+import java.util.List;
+
+public class DiaryRepositoryImplJpa implements DiaryRepository {
+    @Override
+    public void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO) {
+
+    }
+
+    @Override
+    public void updateDiary(DiaryEditRequestDTO diaryEditRequestDTO) {
+
+    }
+
+    @Override
+    public DiaryDetailResponseDTO requestDiaryDetails(long diaryId) {
+        return null;
+    }
+
+    @Override
+    public void deleteDiary(long diaryId) {
+
+    }
+
+    @Override
+    public List<TeamDiariesResponseDTO> requestAllTeamDiaries(long userId) {
+        return null;
+    }
+
+    @Override
+    public List<DiaryIdResponseDTO> requestDiaryId(String diaryTitle, String writtenDate, long writerId) {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/MemberRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/MemberRepositoryImplJpa.java
@@ -1,52 +1,42 @@
-package com.example.demo.repository.mybatisImpl;
+package com.example.demo.repository.jpaImpl;
 
 import com.example.demo.dto.MemberInviteRequestDTO;
 import com.example.demo.dto.MemberUpdateRequestDTO;
-import com.example.demo.mapper.MemberMapper;
 import com.example.demo.repository.inter.MemberRepository;
 import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
-@RequiredArgsConstructor
-@Primary
-public class MemberRepositoryImplMybatis implements MemberRepository {
-    private final MemberMapper memberMapper;
-
+public class MemberRepositoryImplJpa implements MemberRepository {
     @Override
     public void inviteMember(MemberInviteRequestDTO memberInviteRequestDTO) {
-        memberMapper.insertMember(memberInviteRequestDTO);
+
     }
 
     @Override
     public void updateMember(MemberUpdateRequestDTO memberUpdateRequestDTO) {
-        memberMapper.updateMember(memberUpdateRequestDTO);
+
     }
 
     @Override
     public void deleteMember(long id) {
-        memberMapper.deleteMember(id);
+
     }
 
     @Override
     public List<TeamMembersNameResponse> requestTeamMembersName(long teamId) {
-        return memberMapper.requestTeamMembersName(teamId);
+        return null;
     }
 
     @Override
     public List<InvitedListResponse> requestInvitedList(long userId) {
-        return memberMapper.requestInvitedList(userId);
+        return null;
     }
 
     @Override
     public List<TeamRequest> requestUserTeamList(long userId) {
-        return memberMapper.requestUserTeamList(userId);
+        return null;
     }
 }

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
@@ -1,0 +1,30 @@
+package com.example.demo.repository.jpaImpl;
+
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
+import com.example.demo.repository.inter.TeamDiaryRepository;
+import com.example.demo.response.SharedTeamsResponse;
+import com.example.demo.response.TeamDiaryListResponse;
+
+import java.util.List;
+
+public class TeamDiaryRepositoryImplJpa implements TeamDiaryRepository {
+    @Override
+    public void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary) {
+
+    }
+
+    @Override
+    public void deleteTeamDiary(long diaryId, long teamId) {
+
+    }
+
+    @Override
+    public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
+        return null;
+    }
+
+    @Override
+    public List<SharedTeamsResponse> requestSharedTeams(long diaryId) {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamRepositoryImplJpa.java
@@ -1,0 +1,30 @@
+package com.example.demo.repository.jpaImpl;
+
+import com.example.demo.dto.TeamDiaryPostRequestDTO;
+import com.example.demo.repository.inter.TeamDiaryRepository;
+import com.example.demo.response.SharedTeamsResponse;
+import com.example.demo.response.TeamDiaryListResponse;
+
+import java.util.List;
+
+public class TeamRepositoryImplJpa implements TeamDiaryRepository {
+    @Override
+    public void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary) {
+
+    }
+
+    @Override
+    public void deleteTeamDiary(long diaryId, long teamId) {
+
+    }
+
+    @Override
+    public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
+        return null;
+    }
+
+    @Override
+    public List<SharedTeamsResponse> requestSharedTeams(long diaryId) {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/UserRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/UserRepositoryImplJpa.java
@@ -1,0 +1,26 @@
+package com.example.demo.repository.jpaImpl;
+
+import com.example.demo.dto.*;
+import com.example.demo.repository.inter.UserRepository;
+
+public class UserRepositoryImplJpa implements UserRepository {
+    @Override
+    public LoginResponseDTO login(LogInRequestDTO logInRequestDTO) {
+        return null;
+    }
+
+    @Override
+    public void updateUser(UserUpdateRequestDTO userUpdateRequestDTO) {
+
+    }
+
+    @Override
+    public UserResponseDTO getUser(long userId) {
+        return null;
+    }
+
+    @Override
+    public void insertUser(SignupRequestDTO signupRequestDTO) {
+
+    }
+}

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
@@ -5,11 +5,13 @@ import com.example.demo.mapper.DiaryMapper;
 import com.example.demo.model.DiaryModel;
 import com.example.demo.repository.inter.DiaryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Primary
 @Component
 @RequiredArgsConstructor
 public class DiaryRepositoryImplMybatis implements DiaryRepository {

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
@@ -6,12 +6,14 @@ import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import com.example.demo.mapper.TeamDiaryMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Primary
 public class TeamDiaryRepositoryImplMyBatis implements TeamDiaryRepository {
     private final TeamDiaryMapper teamDiaryMapper;
 

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamRepositoryImplMybatis.java
@@ -6,6 +6,7 @@ import com.example.demo.mapper.TeamMapper;
 import com.example.demo.model.TeamModel;
 import com.example.demo.repository.inter.TeamRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
+@Primary
 public class TeamRepositoryImplMybatis implements TeamRepository {
     private final TeamMapper teamMapper;
 

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/UserRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/UserRepositoryImplMybatis.java
@@ -5,10 +5,12 @@ import com.example.demo.mapper.UserMapper;
 import com.example.demo.model.UserModel;
 import com.example.demo.repository.inter.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Primary
 public class UserRepositoryImplMybatis implements UserRepository {
     private final UserMapper userMapper;
 


### PR DESCRIPTION
### 작업 내용
- JPA 기반 repository 구현체 클래스 `repository.jpaImpl.*` 생성
    - `UserRepositoryImplJpa`
    - `TeamRepositoryImplJpa`
    - `DiaryRepositoryImplJpa`
    - `MemberRepositoryImplJpa`
    - `TeamDiaryRepositoryImplJpa`
- JPA용 Spring Data JPA interface 생성
    - `UserJPARepository`
- 기존 MyBatis 기반 구현체 클래스에 `@Primary` 어노테이션 추가
    - 마이그레이션 중 우선적으로 MyBatis 구현체가 주입되도록 설정


### 목적
- 점진적 JPA 마이그레이션을 위해 JPA 구현체를 추가하면서, 기존 서비스에서 MyBatis가 계속 사용되도록 `@Primary` 설정을 통해 의존성 주입 우선순위 지정

### 참고 사항
- JPA 구현체는 아직 미완성 상태이며, 이후 단계적으로 로직 이전 예정
