### PR TITLE
[frontend] refactor: fetchAllDiaries에 error 핸들링 및 header 설정 추가, diary fetch 로직 fetchData에서 분리

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -1,5 +1,22 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export async function fetchAllDiaries(userId) {
-  const res = await fetch(`${BASE_URL}/diaries/all/${userId}`);
-  if (!res.ok) throw new Error('전체 일기 목록을 불러오지 못했습니다.');
-  return (await res.json()).data;
+  try {
+    const res = await fetch(`${BASE_URL}/diaries/all/${userId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}));
+      throw new Error(errorData.message || '전체 일기 목록을 불러오지 못했습니다.');
+    }
+
+    const data = await res.json();
+    return data?.data ?? [];
+  } catch (error) {
+    throw error;
+  }
 }

--- a/frontend/src/views/diaries/mainPage.vue
+++ b/frontend/src/views/diaries/mainPage.vue
@@ -324,6 +324,7 @@ export default {
   mounted() {
     this.$store.dispatch('fetchStoreData');
     this.fetchData();
+    this.fetchAllDiaries();
   },
 
   data() {
@@ -396,7 +397,6 @@ export default {
   methods: {
     async fetchData() {
       const menuList = await Promise.all([
-        { type: 'diaries', url: `${BASE_URL}/diaries/all/${this.userId}` },
         {
           type: 'teams',
           url: `${BASE_URL}/members/userTeamList/${this.userId}`,
@@ -415,8 +415,6 @@ export default {
       this.dataTypeMap = new Map(
         this.dataList.map((data, idx) => [menuList[idx].type, data.data])
       );
-      this.diaryData = this.dataTypeMap.get('diaries');
-      console.log('diaryData: ', this.diaryData);
       this.teamData = this.dataTypeMap.get('teams');
       this.membersData = this.dataTypeMap.get('members');
       this.usersData = this.dataTypeMap.get('users');
@@ -426,6 +424,8 @@ export default {
     async fetchAllDiaries() {
       try {
         this.diaryData = await fetchAllDiaries(this.userId);
+        console.log('diaryData: ', this.diaryData);
+
       } catch (e) {
         this.error = e.message;
       } finally {


### PR DESCRIPTION
### 변경 내용

- `fetchAllDiaries` 함수에 다음 기능 추가:
  - HTTP 요청 시 `Content-Type: application/json` 헤더 설정
  - 응답 실패 시 에러 메시지 파싱 및 사용자 친화적 메시지 출력
  - 네트워크 또는 API 오류에 대한 예외 처리 추가
- 기존에 `fetchData` 함수 내에서 처리하던 일기 목록 로직을 `fetchAllDiaries`로 분리
- `mainPage.vue`에서 `mounted` 시점에 `fetchAllDiaries()` 별도 호출하도록 변경

### 목적

- 네트워크 오류나 서버 응답 문제에 대해 명확한 예외 처리
- fetch 함수들의 책임 분리 및 모듈화
- 코드의 유지보수성과 테스트 용이성 향상