### PR TITLE
[backend] chore: diary.xml에서 미사용 쿼리 제거 및 diary.xml 순서 정리

### DIFF
--- a/backend/src/main/java/com/example/demo/jpa/UserJPARepository.java
+++ b/backend/src/main/java/com/example/demo/jpa/UserJPARepository.java
@@ -1,11 +1,13 @@
-//package com.example.demo.jpa;
-//
-//import com.example.demo.entity.UserEntity;
-//import org.springframework.data.jpa.repository.JpaRepository;
-//import org.springframework.stereotype.Repository;
-//
-//@Repository
-//public interface UserJPARepository extends JpaRepository<UserEntity, Long> {
-//    UserEntity findAllByEmailAndPassword(long email, String password);
-//
-//}
+package com.example.demo.jpa;
+
+import com.example.demo.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserJPARepository extends JpaRepository<UserEntity, Long> {
+    UserEntity findAllByEmailAndPassword(long email, String password);
+
+
+
+}

--- a/backend/src/main/resources/mapper/diary.xml
+++ b/backend/src/main/resources/mapper/diary.xml
@@ -1,24 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.demo.mapper.DiaryMapper">
-    <select id="selectDiaries" resultType="com.example.demo.model.DiaryModel">
-        SELECT id, written_date, writer_id, diary_title, details
-        FROM diaries
-    </select>
-
     <insert id="insertDiary" parameterType="com.example.demo.dto.DiaryWriteRequestDTO">
-        INSERT INTO diaries (id, written_date, writer_id,diary_title, details)
+        INSERT INTO diaries (id, written_date, writer_id, diary_title, details)
         VALUES (#{id}, #{writtenDate}, #{writerId}, #{diaryTitle}, #{details});
     </insert>
 
     <update id="updateDiary" parameterType="com.example.demo.dto.DiaryEditRequestDTO">
         UPDATE diaries
         SET written_date = #{writtenDate},
-            diary_title = #{diaryTitle},
-            writer_id = #{writerId},
-            details = #{details}
+            diary_title  = #{diaryTitle},
+            writer_id    = #{writerId},
+            details      = #{details}
         WHERE id = #{id};
     </update>
+
+    <select id="requestDiaryDetails" resultType="com.example.demo.model.DiaryModel">
+        SELECT d.id,
+               d.written_date AS writtenDate,
+               d.diary_title  AS diaryTitle,
+               d.details,
+               d.writer_id    AS writerId,
+               u.first_name   AS firstName,
+               u.last_name    AS lastName
+        FROM diaries d
+                 JOIN users u ON d.writer_id = u.id
+        WHERE d.id = #{diaryId};
+    </select>
 
     <delete id="deleteDiary">
         DELETE
@@ -27,22 +35,26 @@
     </delete>
 
     <select id="requestAllTeamDiaries" resultType="com.example.demo.dto.TeamDiariesResponseDTO">
-        SELECT DISTINCT d.id, d.written_date AS writtenDate, d.diary_title AS diaryTitle, u.first_name AS firstName, u.last_name AS lastName, u.color, u.initial
-        FROM members m JOIN team_diary td ON td.team_id = m.team_id
-        JOIN diaries d ON d.id = td.diary_id
-        JOIN users u ON u.id = d.writer_id
-        WHERE m.user_id = #{userId} AND m.status = 0;
-    </select>
-
-    <select id="requestDiaryDetails" resultType="com.example.demo.model.DiaryModel">
-        SELECT d.id, d.written_date AS writtenDate, d.diary_title AS diaryTitle, d.details, d.writer_id AS writerId, u.first_name AS firstName, u.last_name AS lastName
-        FROM diaries d JOIN users u ON d.writer_id = u.id
-        WHERE d.id = #{diaryId};
+        SELECT DISTINCT d.id,
+                        d.written_date AS writtenDate,
+                        d.diary_title  AS diaryTitle,
+                        u.first_name   AS firstName,
+                        u.last_name    AS lastName,
+                        u.color,
+                        u.initial
+        FROM members m
+                 JOIN team_diary td ON td.team_id = m.team_id
+                 JOIN diaries d ON d.id = td.diary_id
+                 JOIN users u ON u.id = d.writer_id
+        WHERE m.user_id = #{userId}
+          AND m.status = 0;
     </select>
 
     <select id="requestDiaryId" resultType="com.example.demo.model.DiaryModel">
         SELECT id
         FROM diaries
-        WHERE diary_title = #{diaryTitle} AND written_date = #{writtenDate} AND writer_id = #{writerId}
+        WHERE diary_title = #{diaryTitle}
+          AND written_date = #{writtenDate}
+          AND writer_id = #{writerId}
     </select>
 </mapper>


### PR DESCRIPTION
### 변경 내용

- `diary.xml`에서 사용되지 않는 중복 쿼리 및 불필요한 SQL 제거
- 쿼리 순서를 `DiaryRepositoryMyBatis` 인터페이스 정의 순서와 맞춰 정리하여 가독성 향상
- 추후 JPA repository 함수 생성 시 매핑을 쉽게 하기 위한 정리 작업

