### PR TITLE
[backend] feat: DiaryJPARepository 생성 및 기존 diary 도메인 관련 쿼리 추가

### DIFF
--- a/backend/src/main/java/com/example/demo/jpa/DiaryJPARepository.java
+++ b/backend/src/main/java/com/example/demo/jpa/DiaryJPARepository.java
@@ -1,0 +1,32 @@
+package com.example.demo.jpa;
+
+import com.example.demo.entity.DiaryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DiaryJPARepository extends JpaRepository<DiaryEntity, Long> {
+    @Query("""
+            SELECT d
+            FROM DiaryEntity d
+            JOIN UserEntity u ON d.writerId = u.id
+            WHERE d.id = :diaryId
+            """
+    )
+    Optional<DiaryEntity> findDiaryWithWriterById(Long diaryId);
+
+    @Query("""
+        SELECT DISTINCT d FROM DiaryEntity d
+        JOIN TeamDiaryEntity td ON d.id = td.diary_id
+        JOIN MemberEntity m ON td.team_id = m.team_id
+        JOIN UserEntity u ON d.writerId = u.id
+        WHERE m.user_id = :userId AND m.status = 0
+    """)
+    List<DiaryEntity> findAllTeamDiariesByUserId(Long userId);
+
+    Optional<DiaryEntity> findByDiaryTitleAndWrittenDateAndWriterId(String diaryTitle, String writtenDate, Long writerId);
+}


### PR DESCRIPTION
### 개요

- 기존 MyBatis 기반의 `diary.xml`을 JPA 기반으로 전환하기 위해 `DiaryJPARepository` 새로 생성하였습니다.

---

### 생성된 JPA 메서드 목록

- `findDiaryWithWriterById(Long diaryId)`  
  - 사용자 정보가 JOIN된 일기 상세 조회용

- `findAllTeamDiariesByUserId(Long userId)`  
  - 사용자가 멤버인 모든 팀에 공유된 일기 조회

- `findByDiaryTitleAndWrittenDateAndWriterId(...)`  
  - 특정 조건으로 일기 ID 조회
