### PR TITLE
[backend] chore: member.xml에서 사용하지 않는 쿼리 삭제 및 정렬

### DIFF
--- a/backend/src/main/resources/mapper/member.xml
+++ b/backend/src/main/resources/mapper/member.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.demo.mapper.MemberMapper">
-    <select id="selectMembers" resultType="com.example.demo.model.MemberModel">
-        SELECT id, user_id, team_id, status, inviter_id
-        FROM members
-    </select>
 
     <insert id="insertMember" parameterType="com.example.demo.dto.MemberInviteRequestDTO">
         INSERT INTO members (id, user_id, team_id, status, inviter_id)
@@ -13,9 +9,9 @@
 
     <update id="updateMember" parameterType="com.example.demo.dto.MemberUpdateRequestDTO">
         UPDATE members
-        SET user_id = #{userId},
-            team_id = #{teamId},
-            status = #{status},
+        SET user_id    = #{userId},
+            team_id    = #{teamId},
+            status     = #{status},
             inviter_id = #{inviterId}
         WHERE id = #{id};
     </update>
@@ -26,10 +22,12 @@
         WHERE id = #{memberId};
     </delete>
 
-    <select id="requestTeamMembersName"  resultType="com.example.demo.response.TeamMembersNameResponse">
+    <select id="requestTeamMembersName" resultType="com.example.demo.response.TeamMembersNameResponse">
         SELECT m.user_id, concat(u.last_name, u.first_name) as name, u.color
-        FROM members m JOIN users u ON m.user_id = u.id
-        WHERE team_id = #{team_id} AND m.status=0;
+        FROM members m
+                 JOIN users u ON m.user_id = u.id
+        WHERE team_id = #{team_id}
+          AND m.status = 0;
     </select>
 
     <insert id="requestInviteMember" parameterType="com.example.demo.dto.MemberInviteInTeamRequestDTO">
@@ -39,16 +37,20 @@
 
     <select id="requestInvitedList" resultType="com.example.demo.response.InvitedListResponse">
         SELECT m.id, m.team_id, t.team_name, m.inviter_id, u.first_name, m.status
-        FROM members m JOIN teams t ON m.team_id = t.id
-        JOIN users u ON m.inviter_id = u.id
-        WHERE user_id = #{userId} AND status = 1;
+        FROM members m
+                 JOIN teams t ON m.team_id = t.id
+                 JOIN users u ON m.inviter_id = u.id
+        WHERE user_id = #{userId}
+          AND status = 1;
     </select>
 
     <select id="requestUserTeamList" resultType="com.example.demo.response.UserTeamListResponse">
         SELECT m.team_id, t.team_name
-        FROM members m JOIN teams t
-            ON m.team_id = t.id
+        FROM members m
+                 JOIN teams t
+                      ON m.team_id = t.id
         WHERE user_id = #{userId}
           AND status = 0;
     </select>
+
 </mapper>


### PR DESCRIPTION
### 개요

- `member.xml`의 MyBatis 쿼리 파일에서 사용하지 않는 쿼리를 정리하고, 사용 중인 쿼리들의 순서를 정돈했습니다.
- JPA 전환을 위한 사전 작업으로, 어떤 쿼리가 현재 실제로 사용되는지를 명확하게 파악하기 위한 정리 작업입니다.

---

### 변경 내용

- 사용되지 않는 `<select id="selectMembers">` 쿼리 삭제
- 들여쓰기 및 줄바꿈 정리로 가독성 향상