### PR TITLE
[backend] refactor: UserJPARepository에서 email 파라미터 타입 long → String으로 수정

### DIFF
--- a/backend/src/main/java/com/example/demo/jpa/UserJPARepository.java
+++ b/backend/src/main/java/com/example/demo/jpa/UserJPARepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserJPARepository extends JpaRepository<UserEntity, Long> {
-    UserEntity findAllByEmailAndPassword(long email, String password);
+    UserEntity findAllByEmailAndPassword(String email, String password);
 
 
 


### PR DESCRIPTION
## 📌 개요

- `UserJPARepository` 내 `findAllByEmailAndPassword(...)` 메서드에서 `email` 파라미터 타입이 `long`으로 잘못 지정되어 있어 이를 `String`으로 수정.

---

## 🔧 변경 내용

- `UserJPARepository` 인터페이스
  ```java
  // before
  UserEntity findAllByEmailAndPassword(long email, String password);

  // after
  UserEntity findAllByEmailAndPassword(String email, String password);
