### PR TITLE
[backend] refactor: MemberJPARepository 생성 및 team.xml 정리

### DIFF
--- a/backend/src/main/java/com/example/demo/jpa/MemberJPARepository.java
+++ b/backend/src/main/java/com/example/demo/jpa/MemberJPARepository.java
@@ -1,0 +1,53 @@
+package com.example.demo.jpa;
+
+import com.example.demo.entity.MemberEntity;
+import com.example.demo.response.InvitedListResponse;
+import com.example.demo.response.TeamMembersNameResponse;
+import com.example.demo.response.UserTeamListResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberJPARepository extends JpaRepository<MemberEntity, Long> {
+    @Query("""
+                SELECT new com.example.demo.response.TeamMembersNameResponse(
+                    m.user_id,
+                    CONCAT(u.lastName, u.firstName),
+                    u.color
+                )
+                FROM MemberEntity m
+                JOIN UserEntity u ON m.user_id = u.id
+                WHERE m.team_id = :teamId AND m.status = 0
+            """)
+    List<TeamMembersNameResponse> findTeamMembersNameByTeamId(Long teamId);
+
+    @Query("""
+        SELECT new com.example.demo.response.InvitedListResponse(
+            m.id,
+            m.team_id,
+            t.team_name,
+            m.inviter_id,
+            u.firstName,
+            m.status
+        )
+        FROM MemberEntity m
+        JOIN TeamEntity t ON m.team_id = t.id
+        JOIN UserEntity u ON m.inviter_id = u.id
+        WHERE m.user_id = :userId AND m.status = 1
+    """)
+    List<InvitedListResponse> findInvitedListByUserId(Long userId);
+
+    @Query("""
+        SELECT new com.example.demo.response.UserTeamListResponse(
+            m.team_id,
+            t.team_name
+        )
+        FROM MemberEntity m
+        JOIN TeamEntity t ON m.team_id = t.id
+        WHERE m.user_id = :userId AND m.status = 0
+    """)
+    List<UserTeamListResponse> findUserTeamListByUserId(Long userId);
+}

--- a/backend/src/main/resources/mapper/team.xml
+++ b/backend/src/main/resources/mapper/team.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.demo.mapper.TeamMapper">
-    <select id="selectTeams" resultType="com.example.demo.model.TeamModel">
-        SELECT id, team_name, creator_id
-        FROM teams
+    <select id="searchTeamByDiaryId" resultType="com.example.demo.model.TeamModel">
+        SELECT t.id, t.team_name
+        FROM teams t join team_diary td on t.id=td.team_id
+        WHERE td.diary_id = #{diaryId};
     </select>
 
     <insert id="insertTeam" parameterType="com.example.demo.dto.TeamCreateRequestDTO">
@@ -11,47 +12,9 @@
         VALUES (#{id}, #{team_name}, #{creator_id});
     </insert>
 
-    <update id="updateTeam" parameterType="com.example.demo.model.TeamModel">
-        UPDATE teams
-        SET team_name = #{team_name}
-        WHERE id = #{id};
-    </update>
-
-    <delete id="deleteTeam">
-        DELETE
-        FROM teams
-        WHERE id = #{teamId};
-    </delete>
-
-    <select id="searchTeam" resultType="com.example.demo.model.UserModel">
-        SELECT id, first_name, last_name, email
-        FROM users
-        WHERE email LIKE #{likeSearchWord};
-    </select>
-
-    <select id="searchTeamByDiaryId" resultType="com.example.demo.model.TeamModel">
-        SELECT t.id, t.team_name
-        FROM teams t join team_diary td on t.id=td.team_id
-        WHERE td.diary_id = #{diaryId};
-    </select>
-
     <select id="findTeamId" resultType="com.example.demo.model.TeamModel">
         SELECT id
         FROM teams
         WHERE team_name = #{teamName} AND creator_id = #{creatorId};
     </select>
-
-<!--    <insert id="requestCreateTeam" parameterType="com.example.demo.request.CreateTeamRequest">-->
-<!--        INSERT INTO teams (id, team_name)-->
-<!--        VALUES (#{team_id}, #{team_name});-->
-
-<!--        INSERT INTO members (id, user_id, team_id, status, inviter_id)-->
-<!--        VALUES (#{member_id}, #{user_id}, #{team_id}, #{status}, #{inviter_id});-->
-<!--    </insert>-->
-
-<!--    <select id="requestCurTeamName" parameterType="com.example.demo.model.TeamModel" resultType="com.example.demo.model.TeamModel">-->
-<!--        SELECT team_name-->
-<!--        FROM teams-->
-<!--        WHERE id = #{teamId}-->
-<!--    </select>-->
 </mapper>


### PR DESCRIPTION
### 개요

- 기존 MyBatis 기반의 `member.xml` 쿼리를 대체하기 위한 `MemberJPARepository`를 새로 생성하였습니다.
- 더불어, `team.xml`에서 사용하지 않는 주석 처리된 쿼리 및 중복된 쿼리를 삭제하고 정리하였습니다.

### 변경 내용

#### 1. `MemberJPARepository` 생성
- JPA 기반으로 다음 메서드를 정의:
  - `findTeamMembersNameByTeamId(Long teamId)`
  - `findInvitedListByUserId(Long userId)`
  - `findUserTeamListByUserId(Long userId)`
- DTO 기반 JPQL 사용 (`TeamMembersNameResponse`, `InvitedListResponse`, `UserTeamListResponse` 반환)

#### 2. `team.xml` 정리
- 사용하지 않는 `<select id="selectTeams">`, `<select id="searchTeam">` 등 제거
- 주석 처리된 `requestCreateTeam`, `requestCurTeamName` 등 완전 제거
- 중복 정의된 `searchTeamByDiaryId` 정리
