### PR TITLE
[backend] feat: TeamJPARepository 생성

### DIFF
--- a/backend/src/main/java/com/example/demo/jpa/TeamJPARepository.java
+++ b/backend/src/main/java/com/example/demo/jpa/TeamJPARepository.java
@@ -1,0 +1,19 @@
+package com.example.demo.jpa;
+
+import com.example.demo.entity.TeamEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface TeamJPARepository extends JpaRepository<TeamEntity, Long> {
+    @Query("SELECT t FROM TeamEntity t WHERE t.team_name = :team_name AND t.creator_id = :creator_id")
+    Optional<TeamEntity> findTeamByTeam_nameAndCreator_id(String team_name, Long creator_id);
+
+    @Query("""
+        SELECT t FROM TeamEntity t
+        JOIN TeamDiaryEntity td ON t.id = td.team_id
+        WHERE td.diary_id = :diaryId
+    """)
+    Optional<TeamEntity> findTeamByDiaryId(Long diaryId);
+}


### PR DESCRIPTION
### 개요

기존 MyBatis 기반의 `team.xml` 쿼리를 JPA로 점진적으로 전환하기 위해 `TeamJPARepository`를 새로 생성하였습니다.  
이번 커밋에서는 Repository 정의만 포함되며, 실제 사용처 변경은 이후 커밋에서 진행될 예정입니다.

### 변경 사항

- `TeamJPARepository` 생성 및 쿼리 메서드 정의