### PR TITLE
[backend] fix: TeamDiaryJPARepository 쿼리 실행 오류 수정 (파라미터 이름)

### DIFF
--- a/backend/src/main/java/com/example/demo/jpa/TeamDiaryJPARepository.java
+++ b/backend/src/main/java/com/example/demo/jpa/TeamDiaryJPARepository.java
@@ -35,7 +35,7 @@ public interface TeamDiaryJPARepository extends JpaRepository<TeamDiaryEntity, L
                 )
                 FROM TeamDiaryEntity td
                 JOIN TeamEntity t ON td.team_id = t.id
-                WHERE td.diaryId = :diaryId
+                WHERE td.diary_id = :diaryId
             """)
     List<SharedTeamsResponse> findSharedTeamsByDiaryId(Long diaryId);
 


### PR DESCRIPTION

### 변경 사항

- `findSharedTeamsByDiaryId` JPQL 쿼리 내부의 잘못된 파라미터 이름(`td.diaryId`)을 `td.diary_id`로 수정
