### PR TITLE
[backend] refactor: DiaryWriteRequestDTO에서 불필요한 sharedTeamList 필드 제거

### DIFF
--- a/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTO.java
+++ b/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTO.java
@@ -18,7 +18,6 @@ public class DiaryWriteRequestDTO {
 
     private String firstName;
     private String lastName;
-    private List<TeamModel> sharedTeamList;
 
     public static DiaryWriteRequestDTO from(DiaryModel diaryModel) {
         return DiaryWriteRequestDTO.builder()
@@ -29,7 +28,6 @@ public class DiaryWriteRequestDTO {
                 .details(diaryModel.getDetails())
                 .firstName(diaryModel.getFirstName())
                 .lastName(diaryModel.getLastName())
-                .sharedTeamList(diaryModel.getSharedTeamList())
                 .build();
     }
 }


### PR DESCRIPTION
### 개요

- `DiaryWriteRequestDTO`에 포함되어 있던 `sharedTeamList` 필드는 실제 요청 바디에서 사용되지 않으며, 팀 공유는 애초부터 일기 작성과는 별개의 API에서 처리되므로 해당 필드는 DTO에서 제거하였습니다.

### 변경 사항

- `sharedTeamList` 필드 제거
- `from(DiaryModel)` 내부에서도 해당 필드 매핑 로직 제거
