### PR TITLE
[frontend] refactor: fetchAllDiaries 리턴값 단순화 및 호출부 로직 수정

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -13,9 +13,10 @@ export async function fetchAllDiaries(userId) {
       const errorData = await res.json().catch(() => ({}));
       throw new Error(errorData.message || '전체 일기 목록을 불러오지 못했습니다.');
     }
-
     const data = await res.json();
-    return data?.data ?? [];
+    console.log("data: ", data);
+
+    return data.data;
   } catch (error) {
     throw error;
   }

--- a/frontend/src/views/diaries/mainPage.vue
+++ b/frontend/src/views/diaries/mainPage.vue
@@ -311,16 +311,11 @@
 
 <script>
 import { mapState } from 'vuex';
-<<<<<<< HEAD
 import UserProfile from '@/components/UserProfile.vue'
 import '../../assets/styles.css';
 
 import { fetchAllDiaries } from '@/api/diary.js';
-=======
-import UserProfile from '@/components/UserProfile.vue';
-import '../../assets/styles.css';
-import { fetchAllDiaries } from '@/api/diary';
->>>>>>> main
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export default {
@@ -331,13 +326,8 @@ export default {
   async mounted() {
     this.$store.dispatch('fetchStoreData');
     this.fetchData();
-<<<<<<< HEAD
     
-    const result = await fetchAllDiaries(this.userId);
-    this.diaryData = result.data;
-=======
-    this.fetchAllDiaries();
->>>>>>> main
+    this.diaryData = await fetchAllDiaries(this.userId);
   },
 
   data() {
@@ -410,15 +400,9 @@ export default {
   methods: {
     async fetchData() {
       const menuList = await Promise.all([
-<<<<<<< HEAD
         // { type: 'diaries', url: `${BASE_URL}/diaries/all/${this.userId}` },
         { type: 'teams', url: `${BASE_URL}/members/userTeamList/${this.userId}` },
-=======
-        {
-          type: 'teams',
-          url: `${BASE_URL}/members/userTeamList/${this.userId}`,
-        },
->>>>>>> main
+
         { type: 'members', url: `${BASE_URL}/members` },
         { type: 'users', url: `${BASE_URL}/users` },
         { type: 'invites', url: `${BASE_URL}/members/invited/${this.userId}` },
@@ -429,16 +413,6 @@ export default {
         return res.json();
       });
 
-<<<<<<< HEAD
-      this.dataList = await Promise.all(requests)
-      this.dataTypeMap = new Map(this.dataList.map((data, idx) => [menuList[idx].type, data.data]))
-      // this.diaryData = this.dataTypeMap.get('diaries')
-      // console.log("diaryData: ", this.diaryData);
-      this.teamData = this.dataTypeMap.get('teams')
-      this.membersData = this.dataTypeMap.get('members')
-      this.usersData = this.dataTypeMap.get('users')
-      this.inviteData = this.dataTypeMap.get('invites')
-=======
       this.dataList = await Promise.all(requests);
       this.dataTypeMap = new Map(
         this.dataList.map((data, idx) => [menuList[idx].type, data.data])
@@ -459,7 +433,6 @@ export default {
       } finally {
         this.isLoading = false;
       }
->>>>>>> main
     },
 
     setView(text) {


### PR DESCRIPTION
### PR 요약

- `fetchAllDiaries` 함수의 리턴값을 `res.json().data`로 단순화하여 호출부 코드 가독성 향상
- Vue 컴포넌트 `mounted()` 내부 로직을 간결화하여 `this.diaryData = await fetchAllDiaries(this.userId)` 형태로 변경

### 변경 상세

- `api/diary.js`
  - 기존: `const data = await res.json(); return data?.data ?? []`
  - 변경: `const data = await res.json(); return data.data;` (불필요한 fallback 제거 및 로그 추가)

- `views/diaries/mainPage.vue`
  - `mounted()`에서 API 호출 후 `this.diaryData = result.data` → `this.diaryData = await fetchAllDiaries(this.userId)` 로 단순화

