### PR TITLE
[ci] chore: GitHub Actions 배포 후 Docker image/container/builder 자동 정리 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -108,3 +108,9 @@ jobs:
           docker pull $DOCKER_USER/group-diary-backend:latest
           docker compose -f ~/group-diary/docker-compose.yml up -d
           EOF
+
+      - name: Docker clean after deploy
+        run: |
+          docker image prune -af
+          docker container prune -f
+          docker builder prune -af


### PR DESCRIPTION
### PR 요약

- GitHub Actions 워크플로우에서 배포 후 디스크 사용량을 줄이기 위해 Docker 정리 단계 추가
- `docker image prune`, `container prune`, `builder prune` 등을 통해 불필요한 리소스를 자동 제거

### 변경 사항

- `.github/workflows/deploy.yml`에 아래 명령 추가:

```bash
docker image prune -af
docker container prune -f
docker builder prune -af
