### PR TITLE
[frontend] feat: 사용자의 팀 목록 조회 로직을 fetchUserTeams 함수로 분리 및 mainPage.vue 적용

### DIFF
--- a/frontend/src/api/member.js
+++ b/frontend/src/api/member.js
@@ -1,0 +1,15 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export async function fetchUserTeams(userId) {
+  try {
+    const response = await fetch(`${BASE_URL}/members/userTeamList/${userId}`);
+    if (!response.ok) {
+      throw new Error('팀 목록을 불러오지 못했습니다.');
+    }
+    const data = await response.json();
+    return data.data;
+  } catch (error) {
+    console.error('팀 목록 조회 오류:', error);
+    throw error;
+  }
+}

--- a/frontend/src/views/diaries/mainPage.vue
+++ b/frontend/src/views/diaries/mainPage.vue
@@ -328,6 +328,7 @@ export default {
     this.fetchData();
     
     this.diaryData = await fetchAllDiaries(this.userId);
+    this.teamData = await fetchUserTeams(this.userId);
   },
 
   data() {
@@ -341,7 +342,6 @@ export default {
       dataTypeMap: new Map(),
       diaryData: null,
       teamData: null,
-      membersData: null,
       usersData: null,
       userSearchData: [],
       inviteData: null,
@@ -400,10 +400,6 @@ export default {
   methods: {
     async fetchData() {
       const menuList = await Promise.all([
-        // { type: 'diaries', url: `${BASE_URL}/diaries/all/${this.userId}` },
-        { type: 'teams', url: `${BASE_URL}/members/userTeamList/${this.userId}` },
-
-        { type: 'members', url: `${BASE_URL}/members` },
         { type: 'users', url: `${BASE_URL}/users` },
         { type: 'invites', url: `${BASE_URL}/members/invited/${this.userId}` },
       ]);
@@ -417,8 +413,6 @@ export default {
       this.dataTypeMap = new Map(
         this.dataList.map((data, idx) => [menuList[idx].type, data.data])
       );
-      this.teamData = this.dataTypeMap.get('teams');
-      this.membersData = this.dataTypeMap.get('members');
       this.usersData = this.dataTypeMap.get('users');
       this.inviteData = this.dataTypeMap.get('invites');
     },


### PR DESCRIPTION
### 작업 내용
- 사용자가 속한 팀 목록을 불러오는 API 호출을 `fetchUserTeams` 외부 함수로 분리하여 `frontend/src/api/member.js`에 정의
- `mainPage.vue`의 `mounted()` 훅에서 기존 `fetchData` 내부의 `teamData` 관련 호출을 제거하고 `fetchUserTeams(this.userId)` 호출로 대체
- 코드 가독성과 API 호출 재사용성을 위한 리팩토링 수행

### 변경 파일
- `frontend/src/api/member.js`: `fetchUserTeams` 함수 생성
- `frontend/src/views/diaries/mainPage.vue`: `fetchData()` 내 `userTeamList` 관련 로직 제거, 외부 함수 호출 방식으로 변경
