### PR TITLE
[frontend] feat: 사용자의 초대 알림 목록 조회 로직을 외부 함수로 분리 및 적용

### DIFF
--- a/frontend/src/api/member.js
+++ b/frontend/src/api/member.js
@@ -13,3 +13,17 @@ export async function fetchUserTeams(userId) {
     throw error;
   }
 }
+
+export async function fetchUserInvites(userId) {
+  try {
+    const response = await fetch(`${BASE_URL}/members/invited/${userId}`);
+    if (!response.ok) {
+      throw new Error('초대 목록을 불러오지 못했습니다.');
+    }
+    const data = await response.json();
+    return data.data;
+  } catch (error) {
+    console.error('초대 목록 조회 오류:', error);
+    throw error;
+  }
+}

--- a/frontend/src/views/diaries/mainPage.vue
+++ b/frontend/src/views/diaries/mainPage.vue
@@ -4,7 +4,7 @@
     style="max-width: 1250px; height: 800px; background-color: #aeba94"
   >
     <div class="container">
-      <p v-if="!dataList">로딩...</p>
+      <p v-if="!diaryData">로딩...</p>
       <div v-else>
         <div class="row mt-3">
           <div class="col-2 ms-3 mt-6" style="margin: 10px 0">
@@ -325,10 +325,12 @@ export default {
 
   async mounted() {
     this.$store.dispatch('fetchStoreData');
-    this.fetchData();
-    
+    // this.fetchData();
+    console.log('mounted userId:', this.userId)
+
     this.diaryData = await fetchAllDiaries(this.userId);
     this.teamData = await fetchUserTeams(this.userId);
+    this.inviteData = await fetchUserInvites(this.userId);
   },
 
   data() {
@@ -401,7 +403,6 @@ export default {
     async fetchData() {
       const menuList = await Promise.all([
         { type: 'users', url: `${BASE_URL}/users` },
-        { type: 'invites', url: `${BASE_URL}/members/invited/${this.userId}` },
       ]);
 
       const requests = menuList.map(async (dataReq) => {
@@ -413,8 +414,6 @@ export default {
       this.dataTypeMap = new Map(
         this.dataList.map((data, idx) => [menuList[idx].type, data.data])
       );
-      this.usersData = this.dataTypeMap.get('users');
-      this.inviteData = this.dataTypeMap.get('invites');
     },
 
     async fetchAllDiaries() {


### PR DESCRIPTION
### 주요 변경 사항
- `frontend/src/api/member.js`
  - `fetchUserInvites(userId)` 함수 추가
    - 사용자의 초대 목록을 비동기적으로 가져오는 함수
- `frontend/src/views/diaries/mainPage.vue`
  - `fetchData` 내부의 초대 관련 코드 제거 (`/members/invited` 요청 제거)
  - `mounted()` 훅에서 `fetchUserInvites(this.userId)` 호출 추가하여 외부 함수 사용
  - `v-if="!dataList"` → `v-if="!diaryData"`로 텍스트 조건 변경
