### PR TITLE
[backend] feat: requestTeamId 로직 외부 API 함수로 분리 및 적용

### DIFF
--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -1,25 +1,52 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export async function createTeam(userId, groupNameToCreate) {
-    try {
-        const response = await fetch(`${BASE_URL}/teams`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            team_name: groupNameToCreate,
-            creator_id: userId,
-          }),
-        });
+  try {
+    const response = await fetch(`${BASE_URL}/teams`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        team_name: groupNameToCreate,
+        creator_id: userId,
+      }),
+    });
 
-        if (response.ok) {
-          const responseData = await response.json();
-        } else {
-          const errorData = await response.json();
-          alert(`오류가 발생했습니다: ${errorData.message}`);
-        }
-      } catch (error) {
-        alert(`네트워크 오류가 발생했습니다: ${error.message}`);
-      }
+    if (response.ok) {
+      const responseData = await response.json();
+    } else {
+      const errorData = await response.json();
+      alert(`오류가 발생했습니다: ${errorData.message}`);
+    }
+  } catch (error) {
+    alert(`네트워크 오류가 발생했습니다: ${error.message}`);
   }
+}
+
+export async function fetchTeamId(teamName, creatorId) {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/teams/findId?teamName=${encodeURIComponent(teamName)}&creatorId=${creatorId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (response.ok) {
+      const resjson = await response.json();
+      const teamId = resjson.data;
+      return teamId;
+    } else {
+      const errorData = await response.json();
+      console.log(`team not founded: ${errorData.message}`);
+    }
+  } catch (error) {
+    console.log(
+      `team not founded. 네트워크 오류가 발생했습니다: ${error.message}`
+    );
+  }
+}

--- a/frontend/src/components/CreateTeamModal.vue
+++ b/frontend/src/components/CreateTeamModal.vue
@@ -132,7 +132,7 @@
 <script>
 import { mapState } from 'vuex';
 import { fetchUserSearch } from '@/api/user.js';
-import { createTeam } from '@/api/team.js';
+import { createTeam, fetchTeamId } from '@/api/team.js';
 import { inviteUser } from '@/api/member.js';
 
 
@@ -235,7 +235,7 @@ export default {
     },
 
     async inviteUsers() {
-      const teamData = await this.requestTeamId();
+      const teamData = await fetchTeamId(this.groupNameToCreate, this.userId);
       const teamId = teamData[0].id;
 
       this.requestInviteUser(this.userId, teamId);
@@ -248,59 +248,8 @@ export default {
 
     async requestInviteUser(userId, teamId) {
       await inviteUser(userId, teamId, this.userId);
-    //   const inviteData = {
-    //     userId: userId,
-    //     teamId: teamId,
-    //     status: userId === this.userId ? 0 : 1,
-    //     inviterId: this.userId,
-    //   };
-
-    //   try {
-    //     const response = await fetch(`${BASE_URL}/members`, {
-    //       method: 'POST',
-    //       headers: {
-    //         'Content-Type': 'application/json',
-    //       },
-    //       body: JSON.stringify(inviteData),
-    //     });
-
-    //     if (response.ok) {
-    //       console.log('초대 성공: ', inviteData);
-    //     } else {
-    //       const errorData = await response.json();
-    //       console.log(`오류가 발생했습니다: ${JSON.stringify(errorData)}`);
-    //     }
-    //   } catch (error) {
-    //     alert(`네트워크 오류가 발생했습니다: ${error.message}`);
-    //   }
     },
 
-    async requestTeamId() {
-      try {
-        const response = await fetch(
-          `${BASE_URL}/teams/findId?teamName=${encodeURIComponent(this.groupNameToCreate)}&creatorId=${this.userId}`,
-          {
-            method: 'GET',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        );
-
-        if (response.ok) {
-          const resjson = await response.json();
-          const teamId = resjson.data;
-          return teamId;
-        } else {
-          const errorData = await response.json();
-          console.log(`team not founded: ${errorData.message}`);
-        }
-      } catch (error) {
-        console.log(
-          `team not founded. 네트워크 오류가 발생했습니다: ${error.message}`
-        );
-      }
-    },
   },
 };
 </script> 


### PR DESCRIPTION
### 작업 내용

- 팀 ID 조회를 위한 로직 `requestTeamId`를 `CreateTeamModal.vue` 내부에서 API 유틸 파일로 분리
- `frontend/src/api/team.js`에 `fetchTeamId(teamName, creatorId)` 함수로 정의
- 기존 `CreateTeamModal.vue` 컴포넌트 내의 호출 부분을 외부 API 함수 호출로 교체

### 주요 변경 사항

- `CreateTeamModal.vue` 내 requestTeamId 함수 삭제
- `fetchTeamId(teamName, creatorId)` 함수 API에 새로 추가
- 내부 fetch URL 및 로직은 기존과 동일하되 모듈화 적용
