### PR TITLE
[frontend] feat: 팀 생성 후 store에서 팀 목록 자동 갱신 기능 추가

### DIFF
--- a/frontend/src/components/CreateTeamModal.vue
+++ b/frontend/src/components/CreateTeamModal.vue
@@ -130,7 +130,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapActions } from 'vuex';
 import { fetchUserSearch } from '@/api/user.js';
 import { createTeam, fetchTeamId } from '@/api/team.js';
 import { inviteUser } from '@/api/member.js';
@@ -173,7 +173,9 @@ export default {
   },
 
   methods: {
-    async updateTeamList() {
+    ...mapActions(['updateTeamList']),
+
+    async notifyParent() {
       // 부모 컴포넌트의 updateTeamList 메서드 호출
       this.$emit('team-created');
     },
@@ -212,6 +214,9 @@ export default {
       if (modal) {
         modal.hide();
       }
+
+      // Store에서 팀 목록 갱신
+      await this.updateTeamList();
 
       // 부모 컴포넌트에 이벤트 발생
       this.$emit('team-created');

--- a/frontend/src/stores/store.js
+++ b/frontend/src/stores/store.js
@@ -83,18 +83,24 @@ const store = createStore({
       commit('setTeamList', dataList[0].data);
       commit('setinviteData', dataList[1].data);
       commit('setDiaryData', dataList[2].data);
-
-      // dataList.forEach((data, idx) => {
-      //   commit(`set${menuList[idx].type.charAt(0).toUpperCase() + menuList[idx].type.slice(1)}Data`, data.data);
-      // });
     },
 
-    // updateTeamList({ commit }, teamList) {
-    //   commit('setTeamList', teamList);
-    // },
-    // getters: {
-    //   teamList: state => state.teamList
-    // }
+    // 팀 목록 갱신
+    async updateTeamList({ commit, state }) {
+      try {
+        const response = await fetch(
+          `${BASE_URL}/members/userTeamList/${state.userId}`
+        );
+        if (!response.ok) {
+          throw new Error('팀 목록을 불러오지 못했습니다.');
+        }
+        const data = await response.json();
+        commit('setTeamList', data.data);
+      } catch (error) {
+        console.error('팀 목록 갱신 오류:', error);
+        throw error;
+      }
+    },
   },
 
   plugins: [

--- a/frontend/src/views/diaries/mainPage.vue
+++ b/frontend/src/views/diaries/mainPage.vue
@@ -177,13 +177,13 @@
         </div>
       </div>
       <!-- modal -->
-      <CreateTeamModal @team-created="fetchData" />
+      <CreateTeamModal @team-created="handleTeamCreated" />
     </div>
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapActions } from 'vuex';
 import UserProfile from '@/components/UserProfile.vue'
 import CreateTeamModal from '@/components/CreateTeamModal.vue'
 import '../../assets/styles.css';
@@ -259,7 +259,9 @@ export default {
   },
 
   methods: {
-    async updateTeamList() {
+    ...mapActions(['updateTeamList']),
+
+    async updateTeamListLocal() {
       this.teamData = await fetchUserTeams(this.userId);
     },
 
@@ -281,6 +283,18 @@ export default {
         this.currentPage = page;
         this.fetchData();
       }
+    },
+
+    async handleTeamCreated() {
+      // Store에서 팀 목록 갱신
+      await this.updateTeamList();
+      // 기존 데이터도 갱신
+      await this.fetchData();
+    },
+
+    async fetchData() {
+      this.diaryData = await fetchAllDiaries(this.userId);
+      this.inviteData = await fetchUserInvites(this.userId);
     },
   },
 };

--- a/frontend/src/views/teams/teamPage.vue
+++ b/frontend/src/views/teams/teamPage.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapActions } from 'vuex';
 import UserProfile from '@/components/UserProfile.vue';
 import '../../assets/styles.css';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -96,6 +96,8 @@ export default {
   },
 
   methods: {
+    ...mapActions(['updateTeamList']),
+
     changePage(page) {
       if (page > 0 && page <= this.totalPages) {
         this.currentPage = page;


### PR DESCRIPTION
### 작업 내용

- 팀 생성 완료 시 `vuex store`의 `updateTeamList` 액션을 호출하여 팀 목록 자동 갱신 처리
- `CreateTeamModal.vue` → 팀 생성 후 `updateTeamList()` 호출 추가
- `mainPage.vue` → `@team-created` 이벤트 처리 시 store 갱신 + 기존 데이터 재요청(`fetchData`) 병행
- `store.js` 내 `updateTeamList` 액션 추가 구현:
  - 백엔드 API `/members/userTeamList/{userId}` 호출
  - `teamList` 상태를 `commit`하여 갱신

### 변경 파일

| 파일 | 변경 내용 |
|------|------------|
| `CreateTeamModal.vue` | 팀 생성 후 store의 `updateTeamList()` 호출 추가 |
| `mainPage.vue` | `@team-created` 이벤트 핸들러 `handleTeamCreated()`로 갱신 처리 |
| `store.js` | `updateTeamList` 액션 구현 (fetch 호출 + commit) |
| `teamPage.vue` | store 액션 import 추가 (추후 팀 목록 갱신 활용 가능) |