### PR TITLE
[frontend] refactor: createTeam 및 fetchTeamId 함수 반환 방식 개선 및 에러 처리 통일

### DIFF
--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -15,12 +15,13 @@ export async function createTeam(userId, groupNameToCreate) {
 
     if (response.ok) {
       const responseData = await response.json();
+      return responseData.data;
     } else {
       const errorData = await response.json();
-      alert(`오류가 발생했습니다: ${errorData.message}`);
+      throw new Error(errorData.message || '팀 생성 오류');
     }
   } catch (error) {
-    alert(`네트워크 오류가 발생했습니다: ${error.message}`);
+    throw error;
   }
 }
 
@@ -38,15 +39,12 @@ export async function fetchTeamId(teamName, creatorId) {
 
     if (response.ok) {
       const resjson = await response.json();
-      const teamId = resjson.data;
-      return teamId;
+      return resjson.data;
     } else {
       const errorData = await response.json();
-      console.log(`team not founded: ${errorData.message}`);
+      throw new Error(errorData.message || '팀 조회 오류');
     }
   } catch (error) {
-    console.log(
-      `team not founded. 네트워크 오류가 발생했습니다: ${error.message}`
-    );
+    throw error;
   }
 }


### PR DESCRIPTION
### 작업 내용

- `createTeam` 함수에서 팀 생성 후 서버에서 받은 `responseData.data`를 반환하도록 수정
- `fetchTeamId` 함수도 팀 ID(`resjson.data`)를 바로 반환하도록 단순화
- `alert()` 대신 `throw new Error()` 방식으로 통일된 예외 처리 적용
  - 상위 호출부에서 `try-catch` 구조로 일괄 처리 가능
  - UI 및 로직 분리에 도움

### 변경 전 문제

- API 호출 실패 시 `alert()`으로만 처리되어 재사용성 낮음
- 반환값이 없어 후속 로직에서 응답 데이터를 사용하기 어려움

### 기대 효과

- 응답 결과를 호출한 쪽에서 활용 가능 (e.g. 생성된 팀 ID 등)
- 예외 처리 일관성 확보로 유지보수 용이
- fetch API 함수의 단일 책임 분리 (fetch + 처리 분리)