### PR TITLE
[frontend] feat: 팀 일기 목록 및 팀 멤버 목록 조회 API 함수 추가

### DIFF
--- a/frontend/src/api/member.js
+++ b/frontend/src/api/member.js
@@ -56,3 +56,15 @@ export async function inviteUser(inviteeId, teamId, inviterId) {
     throw error;
   }
 }
+
+export async function fetchTeamMembers(teamId) {
+  try {
+    const response = await fetch(`${BASE_URL}/members/${teamId}`);
+    if (!response.ok) {
+      throw new Error('팀 멤버 목록을 불러오지 못했습니다.');
+    }
+  } catch (error) {
+    console.error('팀 멤버 목록 조회 오류:', error);
+    throw error;
+  }
+}

--- a/frontend/src/api/teamDiary.js
+++ b/frontend/src/api/teamDiary.js
@@ -1,0 +1,19 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export async function fetchTeamDiaryList(teamId) {
+    try {
+        const response = await fetch(`${BASE_URL}/teamDiaries/diaryList/${teamId}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (response.ok) {
+            return response.json();
+        }
+    } catch (error) {
+        console.error('팀 일기 목록 조회 오류:', error);
+        throw error;
+    }
+}


### PR DESCRIPTION
### 작업 내용

- `teamDiary.js` 파일 생성 및 팀별 일기 목록 조회 API 함수 구현
  - `fetchTeamDiaryList(teamId)`  
  - GET `/teamDiaries/diaryList/{teamId}` 호출
- `member.js`에 팀 멤버 조회 API 함수 추가
  - `fetchTeamMembers(teamId)`  
  - GET `/members/{teamId}` 호출

### 기대 효과

- API 호출 로직 분리로 코드 재사용성 및 가독성 향상
