### PR TITLE
[frontend] refactor: 팀 다이어리 조회를 직접 호출 방식에서 외부 API 함수 호출로 변경

### DIFF
--- a/frontend/src/api/teamDiary.js
+++ b/frontend/src/api/teamDiary.js
@@ -10,7 +10,8 @@ export async function fetchTeamDiaryList(teamId) {
         });
 
         if (response.ok) {
-            return response.json();
+            const data = await response.json();
+            return data.data;
         }
     } catch (error) {
         console.error('팀 일기 목록 조회 오류:', error);

--- a/frontend/src/views/teams/teamPage.vue
+++ b/frontend/src/views/teams/teamPage.vue
@@ -2,6 +2,7 @@
 import { mapState, mapActions } from 'vuex';
 import UserProfile from '@/components/UserProfile.vue';
 import { fetchUserTeams } from '@/api/member.js';
+import { fetchTeamDiaryList } from '@/api/teamDiary.js';
 import '../../assets/styles.css';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
@@ -12,12 +13,15 @@ export default {
 
   async mounted() {
     this.$store.dispatch('fetchStoreData');
-    this.teamData = await fetchUserTeams(this.userId);
     this.fetchData();
+
+    this.teamData = await fetchUserTeams(this.userId);
+    this.diaryData = await fetchTeamDiaryList(this.$route.query.team);
   },
   watch: {
-    '$route.query.team': function (newTeam) {
+    '$route.query.team': async function (newTeam) {
       this.fetchData();
+      this.diaryData = await fetchTeamDiaryList(this.$route.query.team);
     },
     teamList(newTeamList) {
       this.teamData = newTeamList;
@@ -108,10 +112,10 @@ export default {
     async fetchData() {
       const teamId = this.$route.query.team;
       const menuList = await Promise.all([
-        {
-          type: 'diaries',
-          url: `${BASE_URL}/teamDiaries/diaryList/${this.$route.query.team}`,
-        },
+        // {
+        //   type: 'diaries',
+        //   url: `${BASE_URL}/teamDiaries/diaryList/${this.$route.query.team}`,
+        // },
         { type: 'teamMembers', url: `${BASE_URL}/members/${teamId}` },
         { type: 'users', url: `${BASE_URL}/users` },
         { type: 'invites', url: `${BASE_URL}/members/invited/${this.userId}` },
@@ -126,8 +130,8 @@ export default {
       this.dataTypeMap = new Map(
         this.dataList.map((data, idx) => [menuList[idx].type, data.data])
       );
-      this.diaryData = this.dataTypeMap.get('diaries');
-      console.log('diaryData: ', this.diaryData);
+      // this.diaryData = this.dataTypeMap.get('diaries');
+      // console.log('diaryData: ', this.diaryData);
 
       this.teamMembersData = this.dataTypeMap.get('teamMembers');
       console.log('teamMembersData: ', this.teamMembersData);
@@ -223,9 +227,10 @@ export default {
       const modalElement = document.getElementById('createGroup-form');
       const modal = bootstrap.Modal.getInstance(modalElement);
       modal.hide();
-      this.fetchData();
 
       this.teamData = await fetchUserTeams(this.userId);
+      this.fetchData();
+
     },
 
     async inviteToTeam() {


### PR DESCRIPTION
### 작업 개요
- 팀 다이어리 목록을 조회할 때 기존에 하드코딩된 fetch 요청을 사용하던 방식을 개선
- 외부 API 유틸 함수 `fetchTeamDiaryList(teamId)`를 사용하여 일관된 방식으로 변경

### 변경 파일
- `frontend/src/api/teamDiary.js`: 응답 형식을 `.json()` → `.data`만 추출하도록 변경
- `frontend/src/views/teams/teamPage.vue`: 팀 다이어리 조회 부분에서 직접 fetch URL 사용하던 코드 제거하고 외부 함수 호출로 대체