### PR TITLE
[frontend] refactor: 초기 데이터 로딩 로직을 initializeData 메서드로 분리

### DIFF
--- a/frontend/src/views/teams/teamPage.vue
+++ b/frontend/src/views/teams/teamPage.vue
@@ -15,8 +15,7 @@ export default {
     this.$store.dispatch('fetchStoreData');
     this.fetchData();
 
-    this.teamData = await fetchUserTeams(this.userId);
-    this.diaryData = await fetchTeamDiaryList(this.$route.query.team);
+    await this.initializeData();
   },
   watch: {
     '$route.query.team': async function (newTeam) {
@@ -110,6 +109,15 @@ export default {
         this.currentPage = page;
         this.teamData = await fetchUserTeams(this.userId);
       }
+    },
+
+    async initializeData() {
+      this.isLoading = true;
+
+      this.teamData = await fetchUserTeams(this.userId);
+      this.diaryData = await fetchTeamDiaryList(this.$route.query.team);
+
+      this.isLoading = false;
     },
 
     async fetchData() {


### PR DESCRIPTION
### Description

- `mounted()` 훅 내부에서 직접 호출하던 `fetchUserTeams`, `fetchTeamDiaryList`를 `initializeData()` 메서드로 분리
- `initializeData()` 내에서 `isLoading` 상태를 관리하여 향후 UI 로딩 처리에 활용 가능하도록 구조 개선

