### PR TITLE
[frontend] refactor: 팀의 멤버 리스트 불러오는 api를 직접 호출에서 외부 api 호출로 변경

### DIFF
--- a/frontend/src/api/member.js
+++ b/frontend/src/api/member.js
@@ -60,6 +60,8 @@ export async function inviteUser(inviteeId, teamId, inviterId) {
 export async function fetchTeamMembers(teamId) {
   try {
     const response = await fetch(`${BASE_URL}/members/${teamId}`);
+    const data = await response.json();
+    return data.data;
     if (!response.ok) {
       throw new Error('팀 멤버 목록을 불러오지 못했습니다.');
     }

--- a/frontend/src/views/teams/teamPage.vue
+++ b/frontend/src/views/teams/teamPage.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import UserProfile from '@/components/UserProfile.vue';
-import { fetchUserTeams } from '@/api/member.js';
+import { fetchUserTeams, fetchTeamMembers } from '@/api/member.js';
 import { fetchTeamDiaryList } from '@/api/teamDiary.js';
 import '../../assets/styles.css';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -116,6 +116,7 @@ export default {
 
       this.teamData = await fetchUserTeams(this.userId);
       this.diaryData = await fetchTeamDiaryList(this.$route.query.team);
+      this.teamMembersData = await fetchTeamMembers(this.$route.query.team);
 
       this.isLoading = false;
     },
@@ -124,7 +125,6 @@ export default {
       this.isLoading = true;
       const teamId = this.$route.query.team;
       const menuList = await Promise.all([
-        { type: 'teamMembers', url: `${BASE_URL}/members/${teamId}` },
         { type: 'users', url: `${BASE_URL}/users` },
         { type: 'invites', url: `${BASE_URL}/members/invited/${this.userId}` },
       ]);
@@ -139,8 +139,6 @@ export default {
         this.dataList.map((data, idx) => [menuList[idx].type, data.data])
       );
 
-      this.teamMembersData = this.dataTypeMap.get('teamMembers');
-      console.log('teamMembersData: ', this.teamMembersData);
       this.usersData = this.dataTypeMap.get('users');
       this.inviteData = this.dataTypeMap.get('invites');
 


### PR DESCRIPTION
### Description

- 팀 멤버 데이터를 조회하던 기존의 직접 fetch 호출 방식을 제거하고,  
  `api/member.js`에 정의한 `fetchTeamMembers(teamId)` 함수로 대체함
- 해당 API 호출을 `teamPage.vue`의 `initializeData()` 내부에서 사용하도록 변경하여 초기 데이터 로딩 흐름을 개선함
- 팀 멤버 API 호출 로직의 **모듈화** 및 **재사용성 향상** 목적의 리팩토링


### 변경 파일

- `frontend/src/api/member.js`:  
  - `fetchTeamMembers(teamId)` 함수 추가  
  - 실패 시 예외 처리 포함

- `frontend/src/views/teams/teamPage.vue`:  
  - 기존 직접 호출 코드 제거  
  - `initializeData()`에서 `fetchTeamMembers` 함수 사용
