### PR TITLE
[frontend] refactor: 선택된 팀을 저장하는 로직 initializeData()로 이동

### DIFF
--- a/frontend/src/views/teams/teamPage.vue
+++ b/frontend/src/views/teams/teamPage.vue
@@ -118,14 +118,16 @@ export default {
       this.diaryData = await fetchTeamDiaryList(this.$route.query.team);
       this.teamMembersData = await fetchTeamMembers(this.$route.query.team);
 
+      this.selectedTeam = this.teamData
+        .filter((t) => t.team_id == this.$route.query.team)
+        .at(0);
+
       this.isLoading = false;
     },
 
     async fetchData() {
       this.isLoading = true;
-      const teamId = this.$route.query.team;
       const menuList = await Promise.all([
-        { type: 'users', url: `${BASE_URL}/users` },
         { type: 'invites', url: `${BASE_URL}/members/invited/${this.userId}` },
       ]);
 
@@ -139,12 +141,8 @@ export default {
         this.dataList.map((data, idx) => [menuList[idx].type, data.data])
       );
 
-      this.usersData = this.dataTypeMap.get('users');
       this.inviteData = this.dataTypeMap.get('invites');
 
-      this.selectedTeam = this.teamData
-        .filter((t) => t.team_id == this.$route.query.team)
-        .at(0);
       this.isLoading = false;
     },
 


### PR DESCRIPTION
### Description
- 기존에 `fetchData()` 내부에서 처리하던 선택된 팀 정보(`selectedTeam`) 저장 로직을 `initializeData()` 메서드로 이동

### 주요 변경 사항

| 항목 | 변경 내용 |
|------|-----------|
| `fetchData()` | `selectedTeam` 설정 코드 제거 |
| `initializeData()` | 팀 정보 조회 이후 `selectedTeam`을 설정하도록 로직 이동 |
| 목적 | 팀 선택 로직을 한 곳(`initializeData`)에서 관리하도록 리팩토링 수행 |