### PR TITLE
[frontend] refactor: 팀 페이지에서 팀 생성 모달을 CreateTeamModal 컴포넌트 적용으로 수정

### DIFF
--- a/frontend/src/components/CreateTeamModal.vue
+++ b/frontend/src/components/CreateTeamModal.vue
@@ -191,7 +191,6 @@ export default {
       this.groupNameToCreate = '';
       this.searchWord = '';
       this.userSearchData = [];
-      this.usersToInvite = [];
     },
 
     async createTeam() {


### PR DESCRIPTION
### Description

- 기존 `teamPage.vue` 내에 직접 작성되어 있던 팀 생성 모달 HTML 및 로직을 전부 제거하고,  
  이를 별도의 컴포넌트 `CreateTeamModal.vue`사용으로 수정


### 변경 파일

- `frontend/src/views/teams/teamPage.vue`
- `frontend/src/components/CreateTeamModal.vue`


### 🔍 주요 변경 사항

| 항목 | 설명 |
|------|------|
| `teamPage.vue` | 팀 생성 모달 관련 전체 HTML/JS 제거, `CreateTeamModal` 컴포넌트 import 및 사용 |
| `CreateTeamModal.vue` | `handleTeamCreated()` 호출을 위한 `emit` 처리 추가 |
| `createTeam()` 등 기존 메서드 | 컴포넌트 내부에서만 사용되도록 이동 및 정리 |