### PR TITLE
[frontend] feat: 팀 멤버 초대 모달을 InviteUserModal 컴포넌트로 분리 및 적용

### DIFF
--- a/frontend/src/components/InviteUserModal.vue
+++ b/frontend/src/components/InviteUserModal.vue
@@ -1,0 +1,205 @@
+<template>
+  <div
+    class="modal fade"
+    id="inviteUser-form"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="inviteUser-form"
+    aria-hidden="true"
+    data-bs-backdrop="static"
+  >
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <!-- 헤더 -->
+        <div class="modal-header">
+          <h5 class="modal-title" id="modal-title-notification">
+            멤버 추가
+          </h5>
+        </div>
+        <!-- body -->
+        <div class="modal-body p-0">
+          <div class="card card-plain">
+            <div class="card-body">
+              <form role="form text-left d-flex">
+                <label>Add friends to this group</label>
+                <form @submit.prevent="searchUser">
+                  <div class="input-group input-group-outline">
+                    <div class="col-8">
+                      <input
+                        v-model="searchWord"
+                        class="form-control me-2"
+                        type="text"
+                        placeholder="Search"
+                      />
+                    </div>
+                    <div class="col-4 ps-0">
+                      <button
+                        @click="searchUser"
+                        class="btn ms-3"
+                        style="background-color: #4f684e; color: #ffffff"
+                        id="searchBtn"
+                      >
+                        Search
+                      </button>
+                    </div>
+                  </div>
+                </form>
+
+                <div id="recipient_input_list" class="d-flex mb-3">
+                  <span
+                    v-for="(user, idx) in usersToInvite"
+                    :key="idx"
+                    class="badge align-items-center p-1 pe-2 text-success-emphasis bg-success-subtle border border-success-subtle rounded-pill"
+                  >
+                    {{ user.lastName }} {{ user.firstName }}
+                    <span class="vr mx-2"></span>
+                    <a
+                      href="javascript:void(0);"
+                      @click="removeFromInviteGroup(user.userId)"
+                    >
+                      <span class="material-icons opacity-6 me-2 text-md"
+                        >cancel</span
+                      >
+                    </a>
+                  </span>
+                </div>
+
+                <div
+                  v-if="filteredUserSearchData.length === 0"
+                  class="list-group"
+                >
+                  <p>no such user</p>
+                </div>
+                <div v-else class="list-group">
+                  <a
+                    v-for="(user, idx) in filteredUserSearchData"
+                    :key="idx"
+                    @click="
+                      updateClickedUserInfo(
+                        user.id,
+                        user.lastName,
+                        user.firstName
+                      )
+                    "
+                    href="javascript:void(0);"
+                    class="list-group-item list-group-item-action"
+                  >
+                    {{ user.lastName }} {{ user.firstName }}
+                  </a>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <!-- modal footer -->
+        <div class="modal-footer">
+          <button
+            @click="inviteToTeam"
+            type="button"
+            class="btn"
+            style="background-color: #718e71; color: #ffffff"
+          >
+            invite
+          </button>
+
+          <button
+            @click="resetUsersToInvite"
+            type="button"
+            class="btn"
+            data-bs-dismiss="modal"
+            style="background-color: #e5d9c4; color: #000000"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import { fetchUserSearch } from '@/api/user.js';
+import { inviteUser } from '@/api/member.js';
+
+export default {
+  name: 'InviteUserModal',
+  
+  props: {
+    teamId: {
+      type: [String, Number],
+      required: true
+    }
+  },
+
+  emits: ['users-invited'],
+
+  data() {
+    return {
+      searchWord: '',
+      userSearchData: [],
+      usersToInvite: [],
+    };
+  },
+
+  computed: {
+    ...mapState(['userId']),
+
+    filteredUserSearchData() {
+      const invitedUserIds = new Set(
+        this.usersToInvite.map((user) => user.userId)
+      );
+      return this.userSearchData.filter(
+        (user) => user.id !== this.userId && !invitedUserIds.has(user.id)
+      );
+    },
+  },
+
+  methods: {
+    async searchUser() {
+      this.userSearchData = await fetchUserSearch(this.searchWord);
+    },
+
+    updateClickedUserInfo(userId, lastName, firstName) {
+      this.usersToInvite.push({ userId, lastName, firstName });
+    },
+
+    removeFromInviteGroup(userId) {
+      this.usersToInvite = this.usersToInvite.filter(
+        (user) => user.userId != userId
+      );
+    },
+
+    resetUsersToInvite() {
+      this.usersToInvite = [];
+      this.searchWord = '';
+      this.userSearchData = [];
+    },
+
+    async inviteToTeam() {
+      for (let i = 0; i < this.usersToInvite.length; i++) {
+        let userId = this.usersToInvite[i].userId;
+        await this.requestInviteUser(userId, this.teamId);
+      }
+      alert('팀에 초대되었습니다.');
+      
+      // 모달 닫기
+      const modalElement = document.getElementById('inviteUser-form');
+      const modal = bootstrap.Modal.getInstance(modalElement);
+      if (modal) {
+        modal.hide();
+      }
+
+      this.resetUsersToInvite();
+      
+      // 부모 컴포넌트에 이벤트 발생
+      this.$emit('users-invited');
+    },
+
+    async requestInviteUser(userId, teamId) {
+      await inviteUser(userId, teamId, this.userId);
+    },
+  },
+};
+</script> 

--- a/frontend/src/views/teams/teamPage.vue
+++ b/frontend/src/views/teams/teamPage.vue
@@ -4,6 +4,7 @@ import UserProfile from '@/components/UserProfile.vue';
 import { fetchUserTeams, fetchTeamMembers } from '@/api/member.js';
 import { fetchTeamDiaryList } from '@/api/teamDiary.js';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
+import InviteUserModal from '@/components/InviteUserModal.vue';
 import '../../assets/styles.css';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
@@ -11,6 +12,7 @@ export default {
   components: {
     UserProfile,
     CreateTeamModal,
+    InviteUserModal,
   },
 
   async mounted() {
@@ -39,28 +41,17 @@ export default {
   data() {
     return {
       color: '',
-      searchWord: '',
       selectedTeam: '',
-      dataList: null,
-      dataTypeMap: new Map(),
       diaryData: [],
       teamData: null,
-      membersData: null,
-      usersData: null,
       userSearchData: [],
-      inviteData: null,
       teamMembersData: null,
       usersToInvite: [],
       showMemberList: false,
-      str: '',
 
       isCalendar: false,
       dropdownText: 'list',
-      // 사용자가 속한 team의 이름을 받아와서 배열에 저장.
-      // team name 클릭하면 team page로 이동. (team 정보를 가지고서.),
 
-      clickedUserLastName: '',
-      clickedUserFirstName: '',
       currentPage: 1,
       itemsPerPage: 7,
       isLoading: false,
@@ -72,16 +63,6 @@ export default {
     ...mapState({
       teamList: (state) => state.teamList,
     }),
-
-    filteredUserSearchData() {
-      const invitedUserIds = new Set(
-        this.usersToInvite.map((user) => user.userId)
-      );
-      console.log('invitedUserIds:', invitedUserIds);
-      return this.userSearchData.filter(
-        (user) => user.id !== this.userId && !invitedUserIds.has(user.id)
-      );
-    },
 
     sortedDiaryData() {
       if (!this.diaryData) return [];
@@ -132,28 +113,6 @@ export default {
       this.isCalendar = text === 'calendar';
     },
 
-    // 사용자 검색
-    async searchUser() {
-      try {
-        const response = await fetch(
-          `${BASE_URL}/users/search/?searchWord=${encodeURIComponent(this.searchWord)}`,
-          {
-            method: 'GET',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        );
-        if (response.ok) {
-          const resjson = await response.json();
-          this.userSearchData = resjson.data;
-          console.log(this.userSearchData);
-        }
-      } catch (error) {
-        console.error('Error:', error);
-      }
-    },
-
     // log out
     logOut() {
       this.$store.commit('logOut');
@@ -173,29 +132,9 @@ export default {
       this.$router.push({ path: 'teamPage', query: { team: teamId } });
     },
 
-    // 초대 그룹에 추가
-    addToInviteGroup(userId, lastName, firstName) {
-      this.usersToInvite.push({ userId, lastName, firstName });
-      console.log('userToInvite[]: ', this.usersToInvite);
-    },
-
-    // 초대 그룹에서 삭제
-    removeFromInviteGroup(userId) {
-      console.log(userId);
-      this.usersToInvite = this.usersToInvite.filter(
-        (user) => user.userId != userId
-      );
-      console.log('userToInvite[]: ', this.usersToInvite);
-    },
-
     // usersToInvite 배열 초기화
     resetUsersToInvite() {
       this.usersToInvite = [];
-      this.groupNameToCreate = '';
-      this.searchWord = '';
-      this.userSearchData = [];
-      this.usersToInvite = [];
-      console.log('userToInvite[]: ', this.userToInvite);
     },
 
     // 팀 생성 완료 후 처리
@@ -209,40 +148,6 @@ export default {
       this.teamMembersData = await fetchTeamMembers(this.$route.query.team);
     },
 
-    // 초대 요청 보내기
-    async requestInviteUser(userId, teamId) {
-      // 입력 데이터를 객체로 수집
-      const inviteData = {
-        userId: userId,
-        teamId: teamId,
-        status: userId === this.userId ? 0 : 1,
-        inviterId: this.userId,
-      };
-
-      try {
-        // 서버로 POST 요청 보내기
-        const response = await fetch(`${BASE_URL}/members`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(inviteData),
-        });
-
-        if (response.ok) {
-          // 요청이 성공하면 성공 메시지 표시
-          console.log('초대 성공: ', inviteData);
-        } else {
-          // 요청이 실패하면 오류 메시지 표시
-          const errorData = await response.json();
-          console.log(`오류가 발생했습니다: ${errorData.message}`);
-        }
-      } catch (error) {
-        // 네트워크 오류 처리
-        alert(`네트워크 오류가 발생했습니다: ${error.message}`);
-      }
-    },
-
     toggleShowMemberList() {
       this.showMemberList = !this.showMemberList;
     },
@@ -253,9 +158,6 @@ export default {
       return '';
     },
     lightenColor(color) {
-      // Function to lighten the color
-      // Example: lighten by 50% (increase opacity)
-      // Assuming color is in hex format, convert to rgba and adjust alpha channel
       const rgbaColor = this.hexToRgba(color, 0.5); // 0.5 means 50% opacity
       return rgbaColor;
     },
@@ -508,128 +410,7 @@ export default {
       <CreateTeamModal @team-created="handleTeamCreated" />
 
       <!--inviteUser modal -->
-      <div
-        class="modal fade"
-        id="inviteUser-form"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="inviteUser-form"
-        aria-hidden="true"
-        data-bs-backdrop="static"
-      >
-        <div class="modal-dialog modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <!-- 헤더 -->
-            <div class="modal-header">
-              <h5
-                class="modal-title"
-                @click="initUsersToInvite"
-                id="modal-title-notification"
-              >
-                멤버 추가
-              </h5>
-            </div>
-            <!-- body -->
-            <div class="modal-body p-0">
-              <div class="card card-plain">
-                <div class="card-body">
-                  <form role="form text-left d-flex">
-                    <label>Add friends to this group</label>
-                    <form @submit.prevent="searchUser">
-                      <div class="input-group input-group-outline">
-                        <div class="col-8">
-                          <input
-                            v-model="searchWord"
-                            class="form-control me-2"
-                            type="text"
-                            placeholder="Search"
-                          />
-                        </div>
-                        <div class="col-4 ps-0">
-                          <button
-                            @click="searchUser"
-                            class="btn ms-3"
-                            style="background-color: #4f684e; color: #ffffff"
-                            id="searchBtn"
-                          >
-                            Search
-                          </button>
-                        </div>
-                      </div>
-                    </form>
-
-                    <div id="recipient_input_list" class="d-flex mb-3">
-                      <span
-                        v-for="(user, idx) in usersToInvite"
-                        :key="idx"
-                        class="badge align-items-center p-1 pe-2 text-success-emphasis bg-success-subtle border border-success-subtle rounded-pill"
-                      >
-                        {{ user.lastName }} {{ user.firstName }}
-                        <span class="vr mx-2"></span>
-                        <a
-                          href="javacsript:void(0);"
-                          @click="removeFromInviteGroup(user.userId)"
-                        >
-                          <span class="material-icons opacity-6 me-2 text-md"
-                            >cancel</span
-                          >
-                        </a>
-                      </span>
-                    </div>
-
-                    <div
-                      v-if="filteredUserSearchData.length === 0"
-                      class="list-group"
-                    >
-                      <p>no such user</p>
-                    </div>
-                    <div v-else class="list-group">
-                      <a
-                        v-for="(user, idx) in filteredUserSearchData"
-                        :key="idx"
-                        @click="
-                          updateClickedUserInfo(
-                            user.id,
-                            user.lastName,
-                            user.firstName
-                          )
-                        "
-                        href="javacsript:void(0);"
-                        class="list-group-item list-group-item-action"
-                      >
-                        {{ user.lastName }} {{ user.firstName }}
-                      </a>
-                    </div>
-                    <!-- </form> -->
-                  </form>
-                </div>
-              </div>
-            </div>
-
-            <!-- modal footer -->
-            <div class="modal-footer">
-              <button
-                @click="inviteToTeam"
-                type="button"
-                class="btn"
-                style="background-color: #718e71; color: #ffffff"
-              >
-                invite
-              </button>
-
-              <button
-                @click="resetUsersToInvite"
-                type="button"
-                class="btn"
-                data-bs-dismiss="modal"
-                style="background-color: #e5d9c4; color: #000000"
-              >
-                Close
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <InviteUserModal :teamId="$route.query.team" @users-invited="handleUsersInvited" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Description

- 기존 `teamPage.vue` 내에 직접 구현되어 있던 **팀 멤버 초대 모달**의 템플릿, 로직을 모두 분리하여  
  새로운 컴포넌트 `InviteUserModal.vue`로 분리했습니다.
- 검색, 초대 대상 선택, 멤버 초대 요청 등의 로직이 모두 해당 컴포넌트 내부에서 처리되도록 리팩토링했습니다.
- 기존의 `searchUser`, `requestInviteUser`, `resetUsersToInvite` 등 많은 메서드들이 `teamPage.vue`에서 제거됨으로써 가독성과 유지보수성이 크게 향상되었습니다.
- 초대 완료 시 부모 컴포넌트로 `users-invited` 이벤트를 emit 하여, 이후 처리 (`handleUsersInvited`)를 상위 컴포넌트에서 이어서 수행할 수 있도록 구현했습니다.

### 변경 파일

- `frontend/src/views/teams/teamPage.vue`
- `frontend/src/components/InviteUserModal.vue` (신규)


### 주요 변경 사항 요약

| 항목 | 내용 |
|------|------|
| 모달 분리 | 멤버 초대 관련 템플릿 및 로직을 `InviteUserModal.vue`로 분리 |
| props | 상위로부터 `teamId` 전달받아 초대 요청 수행 |
| emits | 초대 완료 후 `users-invited` 이벤트 emit |
| 정리된 코드 | `searchUser`, `inviteToTeam`, `requestInviteUser`, `resetUsersToInvite` 등 메서드 삭제 |
| 적용 | `<InviteUserModal :teamId="$route.query.team" @users-invited="handleUsersInvited" />` 적용 |
