### PR TITLE
[frontend] refactor: 일기 작성/수정 api 직접 호출에서 외부 함수 호출로 변경

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -21,3 +21,45 @@ export async function fetchAllDiaries(userId) {
     throw error;
   }
 }
+
+export async function createDiary(diaryData) {
+  try {
+    const response = await fetch(`${BASE_URL}/diaries`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(diaryData),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || '일기 작성에 실패했습니다.');
+    }
+
+    return await response.json().data;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function updateDiary(diaryId, diaryData) {
+  try {
+    const response = await fetch(`${BASE_URL}/diaries/edit/${diaryId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(diaryData),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || '일기 수정에 실패했습니다.');
+    }
+
+    return await response.json().data;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/frontend/src/views/diaries/writeDiaryPage.vue
+++ b/frontend/src/views/diaries/writeDiaryPage.vue
@@ -5,6 +5,7 @@ import { mapState } from 'vuex';
 import cancelModal from '@/components/cancelModal.vue';
 import '../../assets/styles.css?v=1.0';
 import { fetchUserTeams } from '@/api/member.js';
+import { createDiary, updateDiary } from '@/api/diary.js';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export default {
@@ -68,6 +69,7 @@ export default {
     updateNeedUpdate() {
       this.needUpdate = !!this.$route.query.diaryId;
     },
+    
     async writeOrUpdateDiary() {
       await this.requestPostOrUpdateDiary();
 
@@ -92,33 +94,12 @@ export default {
     },
 
     async requestPostOrUpdateDiary() {
-      // 일기 post or put
-      var requestUrl = `${BASE_URL}/diaries`;
-      var method = '';
-      if (this.needUpdate) {
-        requestUrl += `/edit/${this.diaryModel.id}`;
-        method = 'PUT';
-      } else {
-        method = 'POST';
-      }
-
       this.diaryModel.writerId = this.userId;
 
-      const response = await fetch(requestUrl, {
-        method: method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(this.diaryModel),
-      });
-
-      if (response.ok) {
-        // 요청이 성공하면 성공 메시지 표시
-        console.log(`${this.needUpdate ? '수정' : '작성'} 성공 `);
+      if (this.needUpdate) {
+        await updateDiary(this.diaryModel.id, this.diaryModel);
       } else {
-        // 요청이 실패하면 오류 메시지 표시
-        const errorData = await response.json();
-        console.log(`오류가 발생했습니다: ${errorData.message}`);
+        await createDiary(this.diaryModel);
       }
     },
 
@@ -134,7 +115,7 @@ export default {
 
     formattedDate(diary) {
       if (diary.writtenDate) {
-        const date = diary.writtenDwrate;
+        const date = diary.writtenDate;
         return `Written Date: ${date.slice(0, 2)}-${date.slice(
           2,
           4
@@ -165,6 +146,7 @@ export default {
         }
       }
     },
+    
     // 작성한 일기의 아이디 요청
     async requestThisDiaryId() {
       try {


### PR DESCRIPTION
### 변경 사항

- `writeDiaryPage.vue`에서 `fetch`를 직접 호출하던 일기 작성 및 수정 API 로직을 제거
- 공통 API 함수인 `createDiary`, `updateDiary`를 `@/api/diary.js`에 작성하고 사용하도록 변경
- 작성/수정 로직 통합 메서드 `requestPostOrUpdateDiary()` 내부 로직 정리

