### PR TITLE
[frontend] refactor: diary detail 조회 api 직접 호출에서 외부 함수 호출로 변경

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -63,3 +63,24 @@ export async function updateDiary(diaryId, diaryData) {
     throw error;
   }
 }
+
+export async function fetchDiaryDetail(diaryId) {
+  try {
+    const response = await fetch(`${BASE_URL}/diaries/details/${diaryId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || '일기 상세 정보를 불러오지 못했습니다.');
+    }
+
+    const data = await response.json();
+    return data.data;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/frontend/src/views/diaries/writeDiaryPage.vue
+++ b/frontend/src/views/diaries/writeDiaryPage.vue
@@ -5,7 +5,7 @@ import { mapState } from 'vuex';
 import cancelModal from '@/components/cancelModal.vue';
 import '../../assets/styles.css?v=1.0';
 import { fetchUserTeams } from '@/api/member.js';
-import { createDiary, updateDiary } from '@/api/diary.js';
+import { createDiary, updateDiary, fetchDiaryDetail } from '@/api/diary.js';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export default {
@@ -13,7 +13,7 @@ export default {
   async mounted() {
     this.updateNeedUpdate();
     if (this.needUpdate) {
-      this.fetchDiaryDetail(this.$route.query.diaryId);
+      this.loadDiaryDetail(this.$route.query.diaryId);
       this.requestSharedTeams();
     }
 
@@ -103,14 +103,16 @@ export default {
       }
     },
 
-    async fetchDiaryDetail(id) {
-      this.diary = null;
-      const res = await fetch(`${BASE_URL}/diaries/details/${id}`);
-      const resBody = await res.json();
-      this.diaryModel = resBody.data;
-      this.editedTeamList = this.deepCopyAndRename(
-        this.diaryModel.sharedTeamList
-      );
+    async loadDiaryDetail() {
+      try {
+        this.diaryModel = await fetchDiaryDetail(this.diaryId);
+        this.editedTeamList = this.deepCopyAndRename(
+          this.diaryModel.sharedTeamList
+        );
+      } catch (error) {
+        console.error('일기 상세 정보 로드 실패:', error);
+        alert(`일기 정보를 불러오지 못했습니다: ${error.message}`);
+      }
     },
 
     formattedDate(diary) {


### PR DESCRIPTION
### 변경 사항

- `writeDiaryPage.vue` 내에서 `fetch`로 직접 일기 상세 데이터를 조회하던 로직 제거
- `@/api/diary.js`에 `fetchDiaryDetail()` 함수 정의 및 적용
- `fetchDiaryDetail()` → `loadDiaryDetail()` 메서드로 교체하여 코드 정리 및 예외 처리 추가

### 변경 파일

- `frontend/src/api/diary.js`: `fetchDiaryDetail()` 함수 추가
- `frontend/src/views/diaries/writeDiaryPage.vue`: 기존 `fetchDiaryDetail()` 직접 호출 제거 및 외부 함수 사용으로 대체
