### PR TITLE
[frontend] refactor: diary id 조회 api 직접 호출에서 외부 함수 호출로 변경

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -84,3 +84,29 @@ export async function fetchDiaryDetail(diaryId) {
     throw error;
   }
 }
+
+export async function findDiaryId(diaryTitle, writtenDate, writerId) {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/diaries/findDiaryId?diaryTitle=${encodeURIComponent(
+        diaryTitle
+      )}&writtenDate=${writtenDate}&writerId=${writerId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || '일기 ID를 찾을 수 없습니다.');
+    }
+
+    const data = await response.json();
+    return data.data[0].id;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/frontend/src/views/diaries/writeDiaryPage.vue
+++ b/frontend/src/views/diaries/writeDiaryPage.vue
@@ -152,41 +152,6 @@ export default {
         }
       }
     },
-    
-    // 작성한 일기의 아이디 요청
-    async requestThisDiaryId() {
-      try {
-        const response = await fetch(
-          `${BASE_URL}/diaries/findDiaryId?diaryTitle=${encodeURIComponent(
-            this.diaryModel.diaryTitle
-          )}&writtenDate=${this.diaryModel.writtenDate}&writerId=${
-            this.userId
-          }`,
-          {
-            method: 'GET',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        );
-
-        if (response.ok) {
-          const resjson = await response.json();
-
-          const diaryId = resjson.data[0].id;
-          return diaryId;
-        } else {
-          // 요청이 실패하면 오류 메시지 표시
-          const errorData = await response.json();
-          console.log(`diary not founded: ${errorData.message}`);
-        }
-      } catch (error) {
-        // 네트워크 오류 처리
-        console.log(
-          `diary not founded. 네트워크 오류가 발생했습니다: ${error.message}`
-        );
-      }
-    },
 
     async requestShareDiary(diaryId, teamId) {
       // 입력 데이터를 객체로 수집

--- a/frontend/src/views/diaries/writeDiaryPage.vue
+++ b/frontend/src/views/diaries/writeDiaryPage.vue
@@ -5,7 +5,7 @@ import { mapState } from 'vuex';
 import cancelModal from '@/components/cancelModal.vue';
 import '../../assets/styles.css?v=1.0';
 import { fetchUserTeams } from '@/api/member.js';
-import { createDiary, updateDiary, fetchDiaryDetail } from '@/api/diary.js';
+import { createDiary, updateDiary, fetchDiaryDetail, findDiaryId } from '@/api/diary.js';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export default {
@@ -75,7 +75,11 @@ export default {
 
       // 일기 작성 페이지이면
       if (!this.needUpdate) {
-        const diaryId = await this.requestThisDiaryId();
+        const diaryId = await findDiaryId(
+          this.diaryModel.diaryTitle,
+          this.diaryModel.writtenDate,
+          this.userId
+        );
 
         // 선택한 팀들에 일기 공유
         for (let i = 0; i < this.teamListToShare.length; i++) {


### PR DESCRIPTION
### 변경 사항
- `writeDiaryPage.vue`에서 `requestThisDiaryId()` 직접 fetch 호출을 제거했습니다.
- 해당 기능은 외부 API 호출 함수인 `findDiaryId()`를 통해 대체했습니다.
- `requestThisDiaryId()` 함수 전체 제거 및 `findDiaryId()` 함수는 `@/api/diary.js`로 분리하여 작성.

### 주요 변경 파일
- `frontend/src/views/diaries/writeDiaryPage.vue`
  - fetch 직접 호출 → `findDiaryId()` 외부 함수 사용
  - `requestThisDiaryId()` 함수 제거
- `frontend/src/api/diary.js`
  - `findDiaryId(diaryTitle, writtenDate, writerId)` 함수 추가