### PR TITLE
[frontend] refactor: 일기 공유 로직 직접 호출에서 외부 함수 호출로 변경

### DIFF
--- a/frontend/src/api/teamDiary.js
+++ b/frontend/src/api/teamDiary.js
@@ -1,20 +1,49 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export async function fetchTeamDiaryList(teamId) {
-    try {
-        const response = await fetch(`${BASE_URL}/teamDiaries/diaryList/${teamId}`, {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
+  try {
+    const response = await fetch(
+      `${BASE_URL}/teamDiaries/diaryList/${teamId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
 
-        if (response.ok) {
-            const data = await response.json();
-            return data.data;
-        }
-    } catch (error) {
-        console.error('팀 일기 목록 조회 오류:', error);
-        throw error;
+    if (response.ok) {
+      const data = await response.json();
+      return data.data;
     }
+  } catch (error) {
+    console.error('팀 일기 목록 조회 오류:', error);
+    throw error;
+  }
+}
+
+export async function shareDiary(diaryId, teamId) {
+  try {
+    const shareDiaryData = {
+      diary_id: diaryId,
+      team_id: teamId,
+    };
+
+    const response = await fetch(`${BASE_URL}/teamDiaries`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(shareDiaryData),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || '일기 공유에 실패했습니다.');
+    }
+
+    return await response.json();
+  } catch (error) {
+    throw error;
+  }
 }

--- a/frontend/src/views/diaries/writeDiaryPage.vue
+++ b/frontend/src/views/diaries/writeDiaryPage.vue
@@ -6,6 +6,7 @@ import cancelModal from '@/components/cancelModal.vue';
 import '../../assets/styles.css?v=1.0';
 import { fetchUserTeams } from '@/api/member.js';
 import { createDiary, updateDiary, fetchDiaryDetail, findDiaryId } from '@/api/diary.js';
+import { shareDiary } from '@/api/teamDiary.js';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export default {
@@ -82,9 +83,8 @@ export default {
         );
 
         // 선택한 팀들에 일기 공유
-        for (let i = 0; i < this.teamListToShare.length; i++) {
-          const teamId = this.teamListToShare[i].id;
-          await this.requestShareDiary(diaryId, teamId);
+        for (const team of this.teamListToShare) {
+          await shareDiary(diaryId, team.id);
         }
 
         this.$router.go(-1);


### PR DESCRIPTION
### 변경 내용

- 기존에 `writeDiaryPage.vue`에서 직접 fetch로 호출하던 일기 공유 POST 요청을 제거
- 해당 로직을 `@/api/teamDiary.js`에 정의한 `shareDiary(diaryId, teamId)` 외부 함수로 대체

### 주요 변경 파일

- `frontend/src/api/teamDiary.js`
  - `shareDiary()` 함수 추가: `POST /teamDiaries` 호출 및 응답 핸들링
- `frontend/src/views/diaries/writeDiaryPage.vue`
  - 기존 공유 루프 내 `requestShareDiary()` 제거
  - 외부 함수 `shareDiary()` 사용하여 일기 공유 처리