### PR TITLE
[frontend] refactor: diary detail에서 사용되는 api 호출 모두 외부 api 호출로 변경

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -110,3 +110,21 @@ export async function findDiaryId(diaryTitle, writtenDate, writerId) {
     throw error;
   }
 }
+
+export async function deleteDiary(diaryId) {
+  try {
+    const response = await fetch(`${BASE_URL}/diaries/${diaryId}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || '일기 삭제에 실패했습니다.');
+    }
+    return true;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/frontend/src/views/diaries/diaryDetailPage.vue
+++ b/frontend/src/views/diaries/diaryDetailPage.vue
@@ -92,6 +92,7 @@
 <script>
 import { mapState } from 'vuex';
 import UserProfile from '@/components/UserProfile.vue';
+import { fetchDiaryDetail, deleteDiary } from '@/api/diary.js';
 import '../../assets/styles.css?v=1.0';
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
@@ -101,7 +102,6 @@ export default {
   },
   mounted() {
     this.fetchData();
-    this.$store.dispatch('fetchData');
   },
   computed: {
     ...mapState(['userId']),
@@ -114,12 +114,12 @@ export default {
   methods: {
     async fetchData() {
       this.diary = null;
-      const res = await fetch(
-        `${BASE_URL}/diaries/details/${this.$route.query.diary}`
-      );
-      const resBody = await res.json();
-      this.diary = resBody.data;
-      console.log(this.diary);
+      try {
+        this.diary = await fetchDiaryDetail(this.$route.query.diary);
+        console.log(this.diary);
+      } catch (error) {
+        console.error(error.message);
+      }
     },
     formattedDate(diary) {
       if (diary.writtenDate) {
@@ -135,25 +135,14 @@ export default {
         query: { diaryId: this.diary.id },
       });
     },
+
     async requestDeleteDiary() {
       try {
-        const response = await fetch(
-          `${BASE_URL}/diaries/${this.$route.query.diary}`,
-          {
-            method: 'DELETE',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        );
-        if (response.ok) {
-          alert('삭제되었습니다.');
-          window.history.back();
-        } else {
-          console.error('Error deleting diary');
-        }
+        await deleteDiary(this.diary.id);
+        alert('삭제되었습니다.');
+        window.history.back();  
       } catch (error) {
-        console.error('Error:', error);
+        console.error(error.message);
       }
     },
   },


### PR DESCRIPTION
### PR 내용 요약

`diaryDetailPage.vue`에서 사용하던 **일기 상세 조회 및 삭제 fetch 직접 호출을 제거**하고,  
외부 API 함수(`fetchDiaryDetail`, `deleteDiary`)를 사용하도록 리팩토링했습니다.

### 변경 사항

- `diaryDetailPage.vue`에서 fetch 직접 호출 제거
- `api/diary.js`에 `deleteDiary` 함수 신규 정의
- `fetchDiaryDetail` 함수 기존에 정의된 것 적용
