### PR TITLE
[frontend] refactor: 로그인 API 호출 로직을 외부 모듈로 분리

### DIFF
--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -32,3 +32,22 @@ export async function fetchUserSearch(searchWord) {
     throw error;
   }
 }
+
+export async function logInUser(email, password) {
+  try {
+    const response = await fetch(`${BASE_URL}/users/logIn`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('로그인 API 호출 중 오류:', error);
+    throw error;
+  }
+}

--- a/frontend/src/views/users/logInPage.vue
+++ b/frontend/src/views/users/logInPage.vue
@@ -1,9 +1,7 @@
 <script>
-const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import { logInUser } from '../../api/user.js';
 export default {
-  mounted() {
-    this.fetchData();
-  },
+
   data() {
     return {
       dataList: [],
@@ -14,57 +12,24 @@ export default {
   methods: {
     async logIn() {
       try {
-        const response = await fetch(
-          import.meta.env.VITE_API_BASE_URL + '/users/logIn',
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              email: this.email,
-              password: this.password,
-            }),
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-        const data = await response.json();
-
+        const data = await logInUser(this.email, this.password);
         if (data && data.result === 'success' && data.data.id) {
           alert('로그인이 완료되었습니다.');
-
           this.$store.commit('setUserId', data.data.id);
           this.$store.commit('setFirstName', data.data.firstName);
           this.$store.commit('setLastName', data.data.lastName);
           this.$store.commit('setEmail', this.email);
           this.$store.commit('setPassword', this.password);
           this.$store.commit('setColor', data.data.color);
-
           this.$router.push({ path: 'main' });
         } else {
           console.log(data);
-          console.log(data.data.id);
           alert('이메일 또는 비밀번호가 올바르지 않습니다.');
         }
       } catch (error) {
-        console.error('Fetch 작업에 문제가 발생했습니다:', error);
+        console.error('로그인 작업에 문제가 발생했습니다:', error);
         alert('로그인 실패');
       }
-    },
-
-    async fetchData() {
-      const urls = [`${BASE_URL}/users`];
-
-      const requests = urls.map(async (url) => {
-        const res = await fetch(url);
-        return res.json();
-      });
-
-      this.dataList = await Promise.all(requests);
-      console.log(this.dataList);
     },
   },
 };


### PR DESCRIPTION
### PR 내용 요약

`logInPage.vue`에서 사용하던 **로그인 API 호출(fetch)** 로직을 제거하고,  
`api/user.js`에 정의한 외부 함수 `logInUser(email, password)`를 통해 API 호출을 수행하도록 리팩토링했습니다.

### 변경 사항

- 로그인 요청 로직을 `api/user.js`로 분리
  - `logInUser(email, password)` 함수 신규 정의
- `logInPage.vue`에서는 외부 API 함수만 호출하도록 변경