### PR TITLE
[backend] docs: Swagger UI 적용 및 컨트롤러 메서드에 @Operation 어노테이션 일괄 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/demo/controller/DiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/DiaryController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import com.example.demo.dto.*;
 import com.example.demo.service.DiaryService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,13 +16,15 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
+    @Operation(summary = "일기 생성")
     @PostMapping("/diaries")    // 일기 생성
     public ResponseEntity<String> insertDiary(@RequestBody DiaryWriteRequestDTO diary) {
         diaryService.insertDiary(diary);
         return ResponseEntity.ok("일기 작성 완료");
     }
 
-    @PutMapping("/diaries/edit/{id}")    // 일기 수정
+    @Operation(summary = "일기 수정")
+    @PutMapping("/diaries/edit/{id}")
     public ResponseEntity<String> updateDiary(@PathVariable(required = true) long id, @RequestBody DiaryEditRequestDTO diaryData) {
 
         diaryService.updateDiary(id, diaryData);
@@ -29,7 +32,8 @@ public class DiaryController {
         return ResponseEntity.ok("diary edited.");
     }
 
-    @DeleteMapping("/diaries/{id}") // 일기 삭제
+    @Operation(summary = "일기 삭제")
+    @DeleteMapping("/diaries/{id}")
     public HashMap<String, String> deleteDiary(@PathVariable(required = true) long id, @RequestParam(defaultValue = "succ") String succMsg) {
 
         diaryService.deleteDiary(id);
@@ -39,7 +43,8 @@ public class DiaryController {
         return result;
     }
 
-    @GetMapping("/diaries/all/{userId}")    // 사용자가 속해있는 모든 그룹의 일기 조회
+    @Operation(summary = "사용자가 속해있는 모든 그룹의 일기 조회")
+    @GetMapping("/diaries/all/{userId}")
     public HashMap<String, Object> requestAllTeamDiaries(@PathVariable(required = true) long userId) {
         List<TeamDiariesResponseDTO> data = diaryService.requestAllTeamDiaries(userId);
 
@@ -49,7 +54,8 @@ public class DiaryController {
         return result;
     }
 
-    @GetMapping("/diaries/details/{diaryId}")   // 일기 상세 내용 요청
+    @Operation(summary = "일기 상세 내용 요청")
+    @GetMapping("/diaries/details/{diaryId}")
     public HashMap<String, Object> requestDiaryDetails(@PathVariable(required = true) long diaryId) {
         DiaryDetailResponseDTO data = diaryService.requestDiaryDetails(diaryId);
 

--- a/backend/src/main/java/com/example/demo/controller/MemberController.java
+++ b/backend/src/main/java/com/example/demo/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.example.demo.service.MemberService;
 import com.example.demo.request.TeamRequest;
 import com.example.demo.response.InvitedListResponse;
 import com.example.demo.response.TeamMembersNameResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    // 팀에 멤버로 초대
+    @Operation(summary = "팀에 멤버로 초대")
     @PostMapping("/members")
     public ResponseEntity<String> insertMember(@RequestBody MemberInviteRequestDTO member) {
         memberService.insertMember(member);
@@ -29,7 +30,7 @@ public class MemberController {
         return ResponseEntity.ok("멤버 초대 완료");
     }
 
-    // 멤버 수정 (초대 수락/거절)
+    @Operation(summary = "멤버 수정 (초대 수락/거절)")
     @PutMapping("/members/{id}")
     public ResponseEntity<String> updateMember(@RequestBody MemberUpdateRequestDTO memberData, @PathVariable(required = true) long id) {
         memberData.setId(id);
@@ -42,7 +43,7 @@ public class MemberController {
         return ResponseEntity.ok("멤버 정보 수정 완료");
     }
 
-    // 멤버 삭제 (초대 거절)
+    @Operation(summary = "멤버 삭제 (초대 거절)")
     @DeleteMapping("/members/{id}")
     public ResponseEntity<String> deleteMember(@PathVariable(required = true) long id, @RequestParam(defaultValue = "succ") String succMsg) {
         memberService.deleteMember(id);
@@ -50,7 +51,7 @@ public class MemberController {
         return ResponseEntity.ok("invite refused");
     }
 
-    // 팀에 속한 모든 멤버의 이름 요청
+    @Operation(summary = "팀에 속한 모든 멤버의 이름 요청")
     @GetMapping("/members/{teamId}")
     public HashMap<String, Object> requestTeamMembersName(@PathVariable(required = true) long teamId) {
         List<TeamMembersNameResponse> data = memberService.requestTeamMembersName(teamId);
@@ -61,7 +62,7 @@ public class MemberController {
         return result;
     }
 
-    // 사용자가 초대된 팀 리스트 요청
+    @Operation(summary = "사용자가 초대된 팀 리스트 요청")
     @GetMapping("/members/invited/{userId}")
     public HashMap<String, Object> requestInvitedList(@PathVariable(required = true) long userId) {
         List<InvitedListResponse> data = memberService.requestInvitedList(userId);
@@ -72,7 +73,7 @@ public class MemberController {
         return result;
     }
 
-    // 사용자가 멤버인 팀 리스트 요청
+    @Operation(summary = "사용자가 멤버인 팀 리스트 요청")
     @GetMapping("/members/userTeamList/{userId}")
     public HashMap<String, Object> requestUserTeamList(@PathVariable(required = true) long userId) {
         List<TeamRequest> data = memberService.requestUserTeamList(userId);

--- a/backend/src/main/java/com/example/demo/controller/TeamController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamController.java
@@ -3,6 +3,7 @@ package com.example.demo.controller;
 import com.example.demo.dto.TeamCreateRequestDTO;
 import com.example.demo.dto.TeamSearchIdResponseDTO;
 import com.example.demo.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,7 +16,7 @@ public class TeamController {
 
     private final TeamService teamService;
 
-    // 팀 생성
+    @Operation(summary = "팀 생성")
     @PostMapping("/teams")
     public HashMap<String, String> insertTeam(@RequestBody TeamCreateRequestDTO team) {
         teamService.insertTeam(team);
@@ -24,7 +25,7 @@ public class TeamController {
         return result;
     }
 
-    // 팀 id 조회
+    @Operation(summary = "팀 id 조회")
     @GetMapping("/teams/findId")
     public HashMap<String, Object> findTeamId(@RequestParam(defaultValue = "succ") String teamName, long creatorId) {
         List<TeamSearchIdResponseDTO> data = teamService.findTeamId(teamName, creatorId);

--- a/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/TeamDiaryController.java
@@ -4,6 +4,7 @@ import com.example.demo.dto.TeamDiaryPostRequestDTO;
 import com.example.demo.response.SharedTeamsResponse;
 import com.example.demo.response.TeamDiaryListResponse;
 import com.example.demo.service.TeamDiaryService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +17,7 @@ public class TeamDiaryController {
 
     private final TeamDiaryService teamDiaryService;
 
-    // 팁 일기 생성
+    @Operation(summary = "팁 일기 생성")
     @PostMapping("/teamDiaries")
     public HashMap<String, String> insertTeamDiary(@RequestBody TeamDiaryPostRequestDTO teamDiary) {
         teamDiaryService.insertTeamDiary(teamDiary);
@@ -26,7 +27,7 @@ public class TeamDiaryController {
         return result;
     }
 
-    // 팀 일기 삭제 (공유 해제)
+    @Operation(summary = "팀 일기 삭제 (공유 해제)")
     @DeleteMapping("/teamDiaries")
     public HashMap<String, String> deleteTeamDiary(@RequestParam(defaultValue = "succ") long diaryId, long teamId) {
 
@@ -36,7 +37,7 @@ public class TeamDiaryController {
         return result;
     }
 
-    // 현재 팀에 공유된 일기 리스트 요청
+    @Operation(summary = "현재 팀에 공유된 일기 리스트 요청")
     @GetMapping("/teamDiaries/diaryList/{teamId}")
     public HashMap<String, Object> requestTeamDiaryList(@PathVariable(required = true) long teamId) {
         List<TeamDiaryListResponse> data = teamDiaryService.requestTeamDiaryList(teamId);
@@ -47,7 +48,7 @@ public class TeamDiaryController {
         return result;
     }
 
-    // 선택한 일기가 공유된 팀들의 id, 이름 요청
+    @Operation(summary = "선택한 일기가 공유된 팀들의 id, 이름 요청")
     @GetMapping("/teamDiaries/sharedTeams/{diaryId}")
     public HashMap<String, Object> requestSharedTeams(@PathVariable(required = true) long diaryId) {
         List<SharedTeamsResponse> data = teamDiaryService.requestSharedTeams(diaryId);

--- a/backend/src/main/java/com/example/demo/controller/UserController.java
+++ b/backend/src/main/java/com/example/demo/controller/UserController.java
@@ -4,6 +4,7 @@ import com.example.demo.dto.*;
 import com.example.demo.service.UserService;
 import com.example.demo.service.UserServiceImpl;
 import com.example.demo.model.UserModel;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +18,7 @@ public class UserController {
     private final UserServiceImpl userServiceImpl;
     private final UserService userService;
 
-    // login
+    @Operation(summary = "로그인")
     @PostMapping("/users/logIn")
     public HashMap<String, Object> logIn(@RequestBody LogInRequestDTO user) {
         LoginResponseDTO userId = userService.logIn(user);
@@ -28,14 +29,14 @@ public class UserController {
         return result;
     }
 
-    // 사용자 정보 get
+    @Operation(summary = "사용자 정보 get")
     @GetMapping("/users/{userId}")
     public ResponseEntity<UserResponseDTO> getUser(@PathVariable long userId) {
         UserResponseDTO userResponseDTO = userService.getUser(userId);
         return ResponseEntity.ok(userResponseDTO);
     }
 
-    // 사용자 정보 수정
+    @Operation(summary = "사용자 정보 수정")
     @PutMapping("/users/{id}")
     public HashMap<String, String> updateUser(@RequestBody UserUpdateRequestDTO userData, @PathVariable(required = true) long id) {
         userService.updateUser(id, userData);
@@ -45,7 +46,7 @@ public class UserController {
         return result;
     }
 
-    // 사용자 생성 (회원가입)
+    @Operation(summary = "사용자 생성 (회원가입)")
     @PostMapping("/users")
     public HashMap<String, String> insertUser(@RequestBody SignupRequestDTO user) {
         userService.insertUser(user);
@@ -55,7 +56,7 @@ public class UserController {
         return result;
     }
 
-    // 사용자 삭제
+    @Operation(summary = "사용자 삭제")
     @DeleteMapping("/users/{id}")
     public HashMap<String, String> deleteUser(@PathVariable(required = true) long id, @RequestParam(defaultValue = "succ") String succMsg) {
         userServiceImpl.deleteUser(id);
@@ -65,7 +66,7 @@ public class UserController {
         return result;
     }
 
-    // 사용자 이메일 검색
+    @Operation(summary = "사용자 이메일 검색")
     @GetMapping("/users/search/")
     public HashMap<String, Object> userEmailSearchModel(@RequestParam(defaultValue = "succ") String searchWord) {
         String likeSearchWord = "%" + searchWord + "%";


### PR DESCRIPTION
### 작업 내용
- Swagger 문서화를 위한 springdoc-openapi 의존성 추가 (`build.gradle`)
- Swagger UI를 통해 API 문서 확인 가능 (`/swagger-ui/index.html`)
- `@Operation(summary = "...")` 어노테이션을 모든 컨트롤러의 각 메서드에 적용하여 기능 설명 명시

### 변경된 파일
- `build.gradle`
- `DiaryController.java`
- `MemberController.java`
- `TeamController.java`
- `TeamDiaryController.java`
- `UserController.java`

### Swagger URL
> `/swagger-ui/index.html` 접속 시 전체 API 문서 확인 가능!
