### PR TITLE
[test] feat: 일기 작성 및 삭제 E2E 테스트 시나리오 추가 및 구조 개선

### DIFF
--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
+    baseUrl: 'http://localhost:5173',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/frontend/cypress/e2e/login_and_write_diary.cy.js
+++ b/frontend/cypress/e2e/login_and_write_diary.cy.js
@@ -1,51 +1,69 @@
-describe('일기 공유 시나리오', () => {
-  it('successfully loads', () => {
-    cy.visit('http://localhost:5173')
+describe('일기 작성 시나리오', () => {
+  beforeEach(() => {
+    // BaseURL을 사용하여 로그인 페이지 방문
+    cy.visit('/');
+    cy.url().should('include', '/logIn');
 
-    cy.url().should('include', '/logIn')
+    cy.get('input[type="email"]').type(Cypress.env('TEST_EMAIL'));
+    cy.get('input[type="password"]').type(Cypress.env('TEST_PASSWORD'));
 
-    // 이메일, 비밀번호 입력
-    cy.get('input[type="email"]').type(Cypress.env('TEST_EMAIL'))
-    cy.get('input[type="password"]').type(Cypress.env('TEST_PASSWORD'))
+    cy.get('button[type="button"]').click();
 
-    // 로그인 버튼 클릭
-    cy.get('button[type="button"]').click()
+    cy.url().should('include', '/main');
+  });
 
-    // 로그인 성공 후 URL이 /main으로 리디렉션되었는지 확인
-    cy.url().should('include', '/main')
+  it('일기 작성', () => {
+    // 일기 작성 API 인터셉트 설정
+    cy.intercept('POST', '/diaries').as('createDiary');
+    cy.intercept('POST', '/teamDiaries').as('shareDiary');
+    cy.intercept('GET', '/diaries/findDiaryId*').as('findDiaryId');
 
     // 일기 작성 버튼 클릭
-    cy.contains('Write diary').click()
+    cy.contains('Write diary').click();
 
     // 일기 작성
-    cy.get('input[type="date"]').type('2025-07-31')
-    cy.get('input[type="text"]').type('test')
-    cy.get('textarea').type('testtexts')
-    
+    cy.get('input[type="date"]').type('2025-07-31');
+    cy.get('input[type="text"]').type('test');
+    cy.get('textarea').type('testtexts');
+
     // 팀 선택
-    cy.get('#navbarDropdownMenuLink2').click()
+    cy.get('#navbarDropdownMenuLink2').click();
+    cy.get('.dropdown-menu .dropdown-item').first().click();
+    cy.get('#navbarDropdownMenuLink2').click();
+    cy.get('.dropdown-menu .dropdown-item').first().click();
 
-    // 드롭다운 항목 중 첫 번째 클릭 (filteredTeamData의 첫 팀)
-    cy.get('.dropdown-menu .dropdown-item').first().click()
+    cy.contains('button', 'write diary').click();
 
-    cy.contains('button', 'write diary').click()
-
-    cy.intercept('POST', '/api/diary').as('createDiary')
+    // API 응답 대기
+    cy.wait('@createDiary');
+    cy.wait('@shareDiary');
+    cy.wait('@findDiaryId');
 
     // 일기 작성 완료 후 메인 페이지로 돌아가기
-    cy.url().should('include', '/main')
+    cy.url().should('include', '/main');
+
+    // 작성된 일기 확인 및 클릭
+    cy.contains('test').should('be.visible');
+  });
+
+  it('일기 삭제', () => {
+    // 일기 삭제 API 인터셉트 설정
+    cy.intercept('DELETE', '/diaries/*').as('deleteDiary');
 
     // 작성된 일기 클릭하여 상세 페이지로 이동
-    cy.contains('test').click()
+    cy.contains('test').click();
 
     // 일기 상세 페이지에서 삭제 버튼 클릭
-    cy.contains('button', '삭제').click()
+    cy.contains('button', '삭제').click();
 
     // 삭제 확인 모달에서 확인 버튼 클릭
-    cy.contains('Yes').click()
+    cy.contains('Yes').click();
+
+    // API 응답 대기
+    cy.wait('@deleteDiary');
 
     // 삭제 후 메인 페이지로 돌아가서 일기가 삭제되었는지 확인
-    cy.url().should('include', '/main')
-    cy.contains('test').should('not.exist')
-  })
-})
+    cy.url().should('include', '/main');
+    cy.contains('test').should('not.exist');
+  });
+});


### PR DESCRIPTION
### 주요 변경 사항
- 공통 로그인 로직을 `beforeEach`로 분리하여 중복 제거
- 아래 2개의 실제 동작을 독립적인 테스트 시나리오(`it`)로 분리 및 구현:
  - 일기 작성 시나리오
  - 일기 삭제 시나리오
- 테스트 안정성을 위해 아래 API 경로 인터셉트 설정 추가:
  - `POST /diaries`
  - `POST /teamDiaries`
  - `GET /diaries/findDiaryId*`
  - `DELETE /diaries/*`



### 변경 파일
- `frontend/cypress/e2e/login_and_write_diary.cy.js`  
  ↳ 테스트 코드 리팩토링 및 인터셉트 추가
- `frontend/cypress.config.js`  
  ↳ `baseUrl` 설정 추가 (`http://localhost:5173`)