### PR TITLE
[backend] feat: DiaryMapper 인터페이스에 createDiary 메서드 추가

### DIFF
--- a/backend/src/main/java/com/example/demo/mapper/DiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/mapper/DiaryMapper.java
@@ -1,5 +1,6 @@
 package com.example.demo.mapper;
 
+import com.example.demo.model.Diary;
 import com.example.demo.model.DiaryModel;
 import com.example.demo.dto.DiaryEditRequestDTO;
 import com.example.demo.dto.DiaryWriteRequestDTO;
@@ -13,6 +14,8 @@ import java.util.List;
 @Repository
 public interface DiaryMapper {
     void insertDiary(DiaryWriteRequestDTO diary); // 일기 생성
+
+    void createDiary(Diary diary);
 
     void updateDiary(DiaryEditRequestDTO diary); // 일기 수정
 


### PR DESCRIPTION
### PR 설명

`Diary` 모델 객체를 인자로 받는 `createDiary` 메서드를 `DiaryMapper`에 추가했습니다.  
이 메서드는 **다이어리 작성 v2 API**에서 사용할 예정입니다.

#### 다이어리 작성 v2 API 소개
- 기존에는 **다이어리 생성**과 **팀 공유**를 각각 별도 API로 분리하여 처리했습니다.
- v2에서는 하나의 통합 요청으로 처리 가능하도록 개선 중이며, 그 흐름에서 `createDiary(Diary diary)` 메서드가 사용됩니다.


### 변경된 파일
- `DiaryMapper.java`
  - `createDiary(Diary diary)` 메서드 추가