### PR TITLE
[backend] feat: TeamDiaryMapper에 insertTeamDiaryV2 메서드 및 쿼리 추가

### DIFF
--- a/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
@@ -11,9 +11,11 @@ import java.util.List;
 @Mapper
 @Repository
 public interface TeamDiaryMapper {
-
     // 팁 일기 생성
     void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary);
+
+    // diary 를 팀들에 공유
+    void insertTeamDiaryV2(Long diaryId, List<Long> teamIds);
 
     // 팀 일기 삭제 (공유 해제)
     void deleteTeamDiary(long diaryId, long teamId);

--- a/backend/src/main/resources/mapper/teamDiary.xml
+++ b/backend/src/main/resources/mapper/teamDiary.xml
@@ -6,6 +6,14 @@
         VALUES (#{id}, #{diary_id}, #{team_id});
     </insert>
 
+    <insert id="insertTeamDiaryV2" parameterType="map">
+        INSERT INTO team_diary (diary_id, team_id)
+        VALUES 
+            <foreach collection="teamIds" item="diaryId" separator=",">
+                (#{diaryId}, #{teamId})
+            </foreach>
+    </insert>
+
     <delete id="deleteTeamDiary" parameterType="com.example.demo.model.TeamDiaryModel">
         DELETE
         FROM team_diary


### PR DESCRIPTION
### PR 설명

`TeamDiaryMapper`에 하나의 `diaryId`를 여러 `teamId`에 공유하기 위한  
`insertTeamDiaryV2` 메서드와 쿼리를 추가했습니다.  

이 기능은 **일기 작성 API(v2)**에서  
"일기 생성과 동시에 팀에 공유"를 하나의 요청으로 통합하기 위한 사전 작업입니다.


### 변경된 파일
- `TeamDiaryMapper.java`
  - `insertTeamDiaryV2(Long diaryId, List<Long> teamIds)` 메서드 추가
- `teamDiary.xml`
  - `<insert id="insertTeamDiaryV2">` 다중 insert 쿼리 추가

