### PR TITLE
[backend] feat: 일기 작성 v2 API 통합을 위한 createDiary 및 insertTeamDiaryV2 기능 추가

### DIFF
--- a/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTOv2.java
+++ b/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTOv2.java
@@ -1,0 +1,15 @@
+package com.example.demo.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class DiaryWriteRequestDTOv2 {
+    private long writerId;
+    private String writtenDate;
+    private String title;
+    private String details;
+    private List<Integer> sharedTeamList = new ArrayList<>();
+}

--- a/backend/src/main/java/com/example/demo/model/Diary.java
+++ b/backend/src/main/java/com/example/demo/model/Diary.java
@@ -1,8 +1,14 @@
 package com.example.demo.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Diary {
     private long id;
     private String writtenDate;

--- a/backend/src/main/java/com/example/demo/repository/inter/DiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/DiaryRepository.java
@@ -7,10 +7,15 @@ import java.util.List;
 public interface DiaryRepository {
     void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO);
 
+    long createDiary(DiaryWriteRequestDTOv2 diaryWriteRequestDTOv2);
+
     void updateDiary(DiaryEditRequestDTO diaryEditRequestDTO);
 
     DiaryDetailResponseDTO requestDiaryDetails(long diaryId);
+
     void deleteDiary(long diaryId);
+
     List<TeamDiariesResponseDTO> requestAllTeamDiaries(long userId);
+
     List<DiaryIdResponseDTO> requestDiaryId(String diaryTitle, String writtenDate, long writerId);
 }

--- a/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface TeamDiaryRepository {
     void insertTeamDiary(TeamDiaryPostRequestDTO teamDiary);
 
+    void insertTeamDiaryV2(Long diaryId, List<Long> teamIds);
+
     void deleteTeamDiary(long diaryId, long teamId);
 
     List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/DiaryRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/DiaryRepositoryImplJpa.java
@@ -12,6 +12,11 @@ public class DiaryRepositoryImplJpa implements DiaryRepository {
     }
 
     @Override
+    public long createDiary(DiaryWriteRequestDTOv2 diaryWriteRequestDTOv2) {
+        return 0;
+    }
+
+    @Override
     public void updateDiary(DiaryEditRequestDTO diaryEditRequestDTO) {
 
     }

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
@@ -14,6 +14,11 @@ public class TeamDiaryRepositoryImplJpa implements TeamDiaryRepository {
     }
 
     @Override
+    public void insertTeamDiaryV2(Long diaryId, List<Long> teamIds) {
+
+    }
+
+    @Override
     public void deleteTeamDiary(long diaryId, long teamId) {
 
     }

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
@@ -2,6 +2,7 @@ package com.example.demo.repository.mybatisImpl;
 
 import com.example.demo.dto.*;
 import com.example.demo.mapper.DiaryMapper;
+import com.example.demo.model.Diary;
 import com.example.demo.model.DiaryModel;
 import com.example.demo.repository.inter.DiaryRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,16 @@ public class DiaryRepositoryImplMybatis implements DiaryRepository {
     @Override
     public void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO) {
         diaryMapper.insertDiary(diaryWriteRequestDTO);
+    }
+
+    @Override
+    public long createDiary(DiaryWriteRequestDTOv2 diaryWriteRequestDTOv2) {
+        Diary diary = diaryWriteRequestDTOv2ToModel(diaryWriteRequestDTOv2);
+        diaryMapper.createDiary(diary);
+
+        long diaryId = diary.getId();
+
+        return 0;
     }
 
     @Override
@@ -59,5 +70,14 @@ public class DiaryRepositoryImplMybatis implements DiaryRepository {
                         .sharedTeamList(model.getSharedTeamList())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private Diary diaryWriteRequestDTOv2ToModel(DiaryWriteRequestDTOv2 dto) {
+        return Diary.builder()
+                .writerId(dto.getWriterId())
+                .diaryTitle(dto.getTitle())
+                .details(dto.getDetails())
+                .writtenDate(dto.getWrittenDate())
+                .build();
     }
 }

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
@@ -23,6 +23,11 @@ public class TeamDiaryRepositoryImplMyBatis implements TeamDiaryRepository {
     }
 
     @Override
+    public void insertTeamDiaryV2(Long diaryId, List<Long> teamIds) {
+        teamDiaryMapper.insertTeamDiaryV2(diaryId, teamIds);
+    }
+
+    @Override
     public void deleteTeamDiary(long diaryId, long teamId) {
         teamDiaryMapper.deleteTeamDiary(diaryId, teamId);
 


### PR DESCRIPTION
### PR 설명

**v2 일기 작성 API** 구현을 위한 사전 작업으로 다음과 같은 기능들을 추가했습니다.

#### 주요 변경 사항

- `DiaryWriteRequestDTOv2` 생성: 일기 작성 + 팀 공유 정보를 포함하는 통합 요청 DTO
- `DiaryRepository` 인터페이스 및 구현체에 `createDiary` 메서드 추가
  - MyBatis 구현체에서는 DTO → Diary 모델 변환 및 `diaryMapper.createDiary()` 호출 처리
- `TeamDiaryRepository` 인터페이스 및 구현체(MyBatis, JPA)에 `insertTeamDiaryV2` 메서드 추가
  - 하나의 `diaryId`를 여러 팀 ID와 함께 `team_diary` 테이블에 일괄 insert


### 변경된 파일
- `DiaryWriteRequestDTOv2.java`: v2 요청 DTO 정의
- `DiaryRepository.java`: `createDiary` 메서드 추가
- `DiaryRepositoryImplMybatis.java`: createDiary 구현 + DTO → 모델 변환 로직 추가
- `TeamDiaryRepository.java`: `insertTeamDiaryV2` 메서드 추가
- `TeamDiaryRepositoryImplMyBatis.java`: 메서드 구현 추가
- `TeamDiaryRepositoryImplJpa.java`: 인터페이스 반영용 메서드 정의
- `DiaryRepositoryImplJpa.java`: 인터페이스 반영용 메서드 정의