### PR TITLE
[backend] feat: 일기 작성 API v2 컨트롤러 및 서비스 계층 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/DiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/DiaryController.java
@@ -23,6 +23,13 @@ public class DiaryController {
         return ResponseEntity.ok("일기 작성 완료");
     }
 
+    @Operation(summary = "일기 작성")
+    @PostMapping("/v2/diaries")
+    public ResponseEntity<String> writeDiary(@RequestBody DiaryWriteRequestDTOv2 diary) {
+        diaryService.writeDiary(diary);
+        return ResponseEntity.ok("일기 작성 완료");
+    }
+
     @Operation(summary = "일기 수정")
     @PutMapping("/diaries/edit/{id}")
     public ResponseEntity<String> updateDiary(@PathVariable(required = true) long id, @RequestBody DiaryEditRequestDTO diaryData) {

--- a/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTOv2.java
+++ b/backend/src/main/java/com/example/demo/dto/DiaryWriteRequestDTOv2.java
@@ -11,5 +11,5 @@ public class DiaryWriteRequestDTOv2 {
     private String writtenDate;
     private String title;
     private String details;
-    private List<Integer> sharedTeamList = new ArrayList<>();
+    private List<Long> sharedTeamList = new ArrayList<>();
 }

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
@@ -28,9 +28,7 @@ public class DiaryRepositoryImplMybatis implements DiaryRepository {
         Diary diary = diaryWriteRequestDTOv2ToModel(diaryWriteRequestDTOv2);
         diaryMapper.createDiary(diary);
 
-        long diaryId = diary.getId();
-
-        return 0;
+        return diary.getId();
     }
 
     @Override

--- a/backend/src/main/java/com/example/demo/service/DiaryService.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryService.java
@@ -7,6 +7,8 @@ import java.util.List;
 public interface DiaryService {
     void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO);
 
+    void writeDiary(DiaryWriteRequestDTOv2 diaryWriteRequestDTOv2);
+
     void updateDiary(long id, DiaryEditRequestDTO diaryData);
 
     DiaryDetailResponseDTO requestDiaryDetails(long diaryId);

--- a/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.service;
 
 import com.example.demo.dto.*;
 import com.example.demo.repository.inter.DiaryRepository;
+import com.example.demo.repository.inter.TeamDiaryRepository;
 import com.example.demo.repository.inter.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,11 +14,20 @@ import java.util.List;
 public class DiaryServiceImpl implements DiaryService {
     private final DiaryRepository diaryRepository;
     private final TeamRepository teamRepository;
+    private final TeamDiaryRepository teamDiaryRepository;
 
     // 일기 생성(일기 작성)
     @Override
     public void insertDiary(DiaryWriteRequestDTO diaryWriteRequestDTO) {
         diaryRepository.insertDiary(diaryWriteRequestDTO);
+    }
+
+    @Override
+    public void writeDiary(DiaryWriteRequestDTOv2 diaryWriteRequestDTOv2) {
+        long diaryId = diaryRepository.createDiary(diaryWriteRequestDTOv2);
+
+        // 선택된 팀에 일기 공유
+        teamDiaryRepository.insertTeamDiaryV2(diaryId, diaryWriteRequestDTOv2.getSharedTeamList());
     }
 
     // 일기 수정


### PR DESCRIPTION
### PR 설명

`일기 작성 API v2`의 컨트롤러 및 서비스 계층을 구현했습니다.  
해당 API는 기존과 달리 **일기 생성과 동시에 팀 공유**까지 한 번에 처리하는 통합 흐름입니다.

### 주요 변경 사항

- `DiaryWriteRequestDTOv2` 클래스에 타입 변경 (`List<Integer>` -> `List<Long>`)
- `DiaryController`에 `/v2/diaries` POST API 엔드포인트 추가
- `DiaryService` 및 `DiaryServiceImpl`에 `writeDiary(DiaryWriteRequestDTOv2)` 메서드 구현
  - 내부에서 `createDiary()`로 일기를 생성하고, 생성된 `diaryId`로 `insertTeamDiaryV2()` 호출하여 공유 처리
- `DiaryRepositoryImplMybatis`에서 `createDiary()`가 실제 생성된 `diaryId`를 반환하도록 수정


### 변경된 파일
- `DiaryWriteRequestDTOv2.java`
- `DiaryController.java`
- `DiaryService.java`
- `DiaryServiceImpl.java`
- `DiaryRepositoryImplMybatis.java`