### PR TITLE
[backend] feat: 다이어리 생성 시 자동 생성된 ID 반환 기능 추가

### DIFF
--- a/backend/src/main/resources/mapper/diary.xml
+++ b/backend/src/main/resources/mapper/diary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.demo.mapper.DiaryMapper">
-    <insert id="createDiary" parameterType="com.example.demo.model.Diary">
+    <insert id="createDiary" parameterType="com.example.demo.model.Diary" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO diaries (written_date, writer_id, diary_title, details)
         VALUES (#{writtenDate}, #{writerId}, #{diaryTitle}, #{details})
     </insert>


### PR DESCRIPTION
### PR 설명

`createDiary` 쿼리에 `useGeneratedKeys` 옵션을 추가하여  
다이어리 생성 후 자동 생성된 `id` 값을 Java 객체의 필드로 자동 할당받을 수 있도록 개선했습니다.


### 주요 변경 사항

- `diary.xml`의 `<insert id="createDiary">` 태그에 `useGeneratedKeys="true"` 및 `keyProperty="id"` 속성 추가
- 이제 insert 후 `Diary` 객체의 `id` 필드에 DB에서 생성된 PK 값이 자동으로 주입됨
- 이후 서비스 계층에서 `getId()` 호출 시 생성된 다이어리 ID를 사용할 수 있음


### 변경된 파일
- `diary.xml`