### PR TITLE
[backend] feat: 일기 공유 요청 DTO v2 생성

### DIFF
--- a/backend/src/main/java/com/example/demo/dto/DiaryEditRequestDTOv2.java
+++ b/backend/src/main/java/com/example/demo/dto/DiaryEditRequestDTOv2.java
@@ -1,0 +1,14 @@
+package com.example.demo.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DiaryEditRequestDTOv2 {
+    private Long id;
+    private String title;
+    private String details;
+    private List<Long> addedTeamIds;
+    private List<Long> removedTeamIds;
+}

--- a/backend/src/main/java/com/example/demo/dto/DiaryEditRequestDTOv2.java
+++ b/backend/src/main/java/com/example/demo/dto/DiaryEditRequestDTOv2.java
@@ -9,6 +9,7 @@ public class DiaryEditRequestDTOv2 {
     private Long id;
     private String title;
     private String details;
+    private String writtenDate;
     private List<Long> addedTeamIds;
     private List<Long> removedTeamIds;
 }


### PR DESCRIPTION
### PR 설명

일기 공유 API v2를 만들기 위한 첫 단계로, **Request DTO**를 새롭게 생성.
프론트엔드에서 기존에는 여러 API를 개별 호출하던 구조를 → 하나의 요청으로 처리할 수 있도록 API 구조를 통합하기 위한 작업입니다.


### 변경 목적 (v2 도입 이유)

- 기존에는 일기 내용 수정과 팀 공유/공유 취소를 **각각 API로 분리**해서 호출했음  
- 이를 하나의 통합 API로 만들면 **요청 수 감소 + 트랜잭션 처리 용이 + 응답 일관성** 확보 가능  
- 따라서 v2에서는 `title`, `details`와 함께 `addedTeamIds`, `removedTeamIds`를 모두 한 번에 요청할 수 있도록 설계함


### 작업 계획 (전체 체크리스트)

- [x] 1. `DiaryEditRequestDTOv2` 생성  
- [ ] 2. `DiaryMapper.xml`, `TeamDiaryMapper.xml` 에 쿼리 추가  
  - [ ] - 일기 제목, 내용, 날짜 수정 쿼리 추가  
  - [ ] - 팀 공유 추가 쿼리 추가  
  - [ ] - 팀 공유 취소 쿼리 추가  
- [ ] 3. Mapper 인터페이스에 메서드 선언  
- [ ] 4. Repository 구현 (`MyBatis` 연결)  
- [ ] 5. Service 레이어 구현  
- [ ] 6. Controller에서 통합 API 생성


### 이번 PR 범위

- `DiaryEditRequestDTOv2` 클래스 추가
