### PR TITLE
[backend] feat: 일기 제목, 내용, 날짜 수정 쿼리와 팀 공유 취소 쿼리 추가

### DIFF
--- a/backend/src/main/resources/mapper/diary.xml
+++ b/backend/src/main/resources/mapper/diary.xml
@@ -20,6 +20,14 @@
         WHERE id = #{id};
     </update>
 
+    <update id="updateDiaryV2" parameterType="com.example.demo.dto.DiaryEditRequestDTOv2">
+        UPDATE diaries
+        SET written_date = #{writtenDate},
+            diary_title  = #{diaryTitle},
+            details      = #{details}
+        WHERE id = #{id};
+    </update>
+
     <select id="requestDiaryDetails" resultType="com.example.demo.model.DiaryModel">
         SELECT d.id,
                d.written_date AS writtenDate,

--- a/backend/src/main/resources/mapper/teamDiary.xml
+++ b/backend/src/main/resources/mapper/teamDiary.xml
@@ -21,6 +21,16 @@
           AND team_id = #{teamId};
     </delete>
 
+    <delete id="deleteTeamDiaryV2" parameterType="map">
+        DELETE
+        FROM team_diary
+        WHERE diary_id = #{diaryId}
+        AND team_id IN
+        <foreach collection="teamIds" item="teamId" open="(" separator="," close=")">
+            #{teamId}
+        </foreach>
+    </delete>
+
     <select id="requestTeamDiaryList" resultType="com.example.demo.response.TeamDiaryListResponse">
         SELECT d.id, u.first_name, u.last_name, u.initial, u.color, d.written_date, d.diary_title
         FROM team_diary td


### PR DESCRIPTION
### PR 설명

일기 공유 API v2 개발의 일환으로, 다음 기능을 추가했습니다:

- 일기 수정 쿼리 (`title`, `details`, `written_date` 업데이트)
- 공유 취소된 팀에 대해 `team_diary`에서 삭제하는 쿼리 추가

기존 팀 공유 추가 쿼리는 `insertTeamDiaryV2`를 그대로 재사용할 예정입니다.


### 변경 목적 (v2 도입 이유)

- 기존에는 일기 내용 수정과 팀 공유/공유 취소를 각각 분리된 API로 처리했음  
- 하나의 API로 통합하여 요청 수를 줄이고, 트랜잭션 단위로 처리되도록 개선  
- v2에서는 `DiaryEditRequestDTOv2`를 통해 일기 수정과 팀 공유 내역 변경을 한 번에 처리할 수 있음


### 작업 계획 (전체 체크리스트)

- [x] 1. `DiaryEditRequestDTOv2` 생성  
- [x] 2. `DiaryMapper.xml` 수정  
  - [x] - 일기 제목, 내용, 날짜 수정 쿼리 추가 (`updateDiaryV2`)  
  - [x] - 팀 공유 취소 쿼리 추가 (`deleteTeamDiaryV2`)  
- [ ] 3. Mapper 인터페이스에 메서드 선언  
- [ ] 4. Repository 구현 (`MyBatis` 연결)  
- [ ] 5. Service 레이어 구현  
- [ ] 6. Controller에서 통합 API 생성

🔄 공유 추가 쿼리는 기존의 `insertTeamDiaryV2` 재사용 예정

### 이번 PR 범위

- ✅ `updateDiaryV2` 쿼리 추가 (`diaries` 테이블 내용 수정)  
- ✅ `deleteTeamDiaryV2` 쿼리 추가 (`team_diary`에서 특정 팀 공유 삭제)  
- 🔁 `insertTeamDiaryV2`는 기존 메서드를 그대로 재사용함
