### PR TITLE
[backend] feat: Mapper 인터페이스에 updateDiaryV2, deleteTeamDiary 메서드 선언

### DIFF
--- a/backend/src/main/java/com/example/demo/mapper/DiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/mapper/DiaryMapper.java
@@ -1,5 +1,6 @@
 package com.example.demo.mapper;
 
+import com.example.demo.dto.DiaryEditRequestDTOv2;
 import com.example.demo.model.Diary;
 import com.example.demo.model.DiaryModel;
 import com.example.demo.dto.DiaryEditRequestDTO;
@@ -18,6 +19,8 @@ public interface DiaryMapper {
     void createDiary(Diary diary);
 
     void updateDiary(DiaryEditRequestDTO diary); // 일기 수정
+
+    void updateDiaryV2(DiaryEditRequestDTOv2 diary);
 
     void deleteDiary(long diaryId);  // 일기 삭제
 

--- a/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
@@ -20,6 +20,8 @@ public interface TeamDiaryMapper {
     // 팀 일기 삭제 (공유 해제)
     void deleteTeamDiary(long diaryId, long teamId);
 
+    void deleteTeamDiary(Long diaryId, List<Long> teamIds);
+
     // 현재 팀에 공유된 일기 리스트 요청
     List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
 


### PR DESCRIPTION
### PR 설명

일기 공유 API v2 개발의 일환으로, 다음 Mapper 인터페이스 메서드를 새롭게 선언했습니다:

- `updateDiaryV2(DiaryEditRequestDTOv2 diary)`  
  → 일기 제목, 내용, 날짜를 수정하는 쿼리 매핑용

- `deleteTeamDiary(Long diaryId, List<Long> teamIds)`  
  → 여러 팀에 대한 공유 취소를 한 번에 처리하는 쿼리 매핑용


### 변경 목적 (v2 도입 이유)

- 기존에는 일기 수정, 팀 공유, 공유 취소를 각각 별도 API로 호출해야 했음  
- v2에서는 하나의 통합 API를 통해 수정 및 공유 변경을 한 번에 처리할 수 있도록 구조 개선  
- `DTO`, `Mapper XML`, `Mapper 인터페이스` 레벨에서 단계적으로 작업 중


### 작업 계획 (전체 체크리스트)

- [x] 1. `DiaryEditRequestDTOv2` 생성  
- [x] 2. `DiaryMapper.xml` 수정  
  - [x] - `updateDiaryV2` 쿼리 추가  
  - [x] - `deleteTeamDiaryV2` 쿼리 추가  
- [x] 3. Mapper 인터페이스에 메서드 선언  
  - [x] - `updateDiaryV2()`  
  - [x] - `deleteTeamDiary(diaryId, teamIds)`  
- [ ] 4. Repository 구현 (`MyBatis` 연결)  
- [ ] 5. Service 레이어 구현  
- [ ] 6. Controller에서 통합 API 생성



### 이번 PR 범위

- ✅ `DiaryMapper` 인터페이스에 `updateDiaryV2()` 메서드 추가  
- ✅ `TeamDiaryMapper` 인터페이스에 `deleteTeamDiary(Long, List<Long>)` 메서드 추가