### PR TITLE
[backend] feat: updateDiaryV2, deleteTeamDiaryV2 Repository 메서드 정의

### DIFF
--- a/backend/src/main/java/com/example/demo/repository/inter/DiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/DiaryRepository.java
@@ -11,6 +11,8 @@ public interface DiaryRepository {
 
     void updateDiary(DiaryEditRequestDTO diaryEditRequestDTO);
 
+    void updateDiaryV2(DiaryEditRequestDTOv2 diaryEditRequestDTOv2);
+
     DiaryDetailResponseDTO requestDiaryDetails(long diaryId);
 
     void deleteDiary(long diaryId);

--- a/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
@@ -13,6 +13,8 @@ public interface TeamDiaryRepository {
 
     void deleteTeamDiary(long diaryId, long teamId);
 
+    void deleteTeamDiaryV2(Long diaryId, List<Long> teamIds);
+
     List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
 
     List<SharedTeamsResponse> requestSharedTeams(long diaryId);

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/DiaryRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/DiaryRepositoryImplJpa.java
@@ -22,6 +22,11 @@ public class DiaryRepositoryImplJpa implements DiaryRepository {
     }
 
     @Override
+    public void updateDiaryV2(DiaryEditRequestDTOv2 diaryEditRequestDTOv2) {
+
+    }
+
+    @Override
     public DiaryDetailResponseDTO requestDiaryDetails(long diaryId) {
         return null;
     }

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
@@ -24,6 +24,11 @@ public class TeamDiaryRepositoryImplJpa implements TeamDiaryRepository {
     }
 
     @Override
+    public void deleteTeamDiaryV2(Long diaryId, List<Long> teamIds) {
+
+    }
+
+    @Override
     public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
         return null;
     }

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/DiaryRepositoryImplMybatis.java
@@ -37,6 +37,11 @@ public class DiaryRepositoryImplMybatis implements DiaryRepository {
     }
 
     @Override
+    public void updateDiaryV2(DiaryEditRequestDTOv2 diaryEditRequestDTOv2) {
+        diaryMapper.updateDiaryV2(diaryEditRequestDTOv2);
+    }
+
+    @Override
     public DiaryDetailResponseDTO requestDiaryDetails(long diaryId) {
         DiaryModel diaryModel = diaryMapper.requestDiaryDetails(diaryId);
         return DiaryDetailResponseDTO.from(diaryModel);

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
@@ -34,6 +34,11 @@ public class TeamDiaryRepositoryImplMyBatis implements TeamDiaryRepository {
     }
 
     @Override
+    public void deleteTeamDiaryV2(Long diaryId, List<Long> teamIds) {
+        teamDiaryMapper.deleteTeamDiary(diaryId, teamIds);
+    }
+
+    @Override
     public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
         return teamDiaryMapper.requestTeamDiaryList(teamId);
     }


### PR DESCRIPTION
### PR 설명

일기 공유 API v2 구현의 일환으로, Repository 계층에서 다음 메서드를 새롭게 정의하고 구현했습니다:

- `updateDiaryV2(DiaryEditRequestDTOv2 dto)`  
  → 일기 제목, 내용, 날짜 수정 기능 처리용  
- `deleteTeamDiaryV2(Long diaryId, List<Long> teamIds)`  
  → 특정 일기에 대해 공유가 해제된 팀 ID 목록을 받아 team_diary에서 일괄 삭제

MyBatis 기반 구현은 실제 Mapper 메서드 호출로 연결하였고, JPA 구현은 현재 비워둔 상태입니다.


### 변경 목적 (v2 도입 이유)

- 기존에는 일기 수정, 팀 공유/공유 해제를 각각 다른 API로 나눠 처리하고 있었음  
- 하나의 통합 API 요청으로 모두 처리되도록 구조 개선 중  
- Service 레이어에서 실제 기능 수행을 위한 Repository 메서드 정의 및 연결 필요


### 작업 계획 (전체 체크리스트)

- [x] 1. `DiaryEditRequestDTOv2` 생성  
- [x] 2. `DiaryMapper.xml` 수정  
- [x] 3. Mapper 인터페이스 메서드 선언  
- [x] 4. Repository 인터페이스 선언  
  - [x] - `updateDiaryV2`  
  - [x] - `deleteTeamDiaryV2`  
- [x] 5. Repository MyBatis 구현  
  - [x] - `DiaryRepositoryImplMybatis`  
  - [x] - `TeamDiaryRepositoryImplMyBatis`  
- [x] 6. Repository JPA 구현 (현재 내부 미구현 상태)  
- [ ] 7. Service 레이어 구현  
- [ ] 8. Controller에서 통합 API 생성


### 이번 PR 범위

- ✅ `DiaryRepository`, `TeamDiaryRepository` 인터페이스에 v2 메서드 정의  
- ✅ `DiaryRepositoryImplMybatis` 및 `TeamDiaryRepositoryImplMyBatis` 구현  
- `ImplJpa` 클래스는 현재 내부 로직 없이 선언만 해둔 상태