### PR TITLE
feat: updateDiary Service 메서드 정의 및 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/service/DiaryService.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryService.java
@@ -11,6 +11,8 @@ public interface DiaryService {
 
     void updateDiary(long id, DiaryEditRequestDTO diaryData);
 
+    void updateDiary(DiaryEditRequestDTOv2 diaryEditRequestDTOv2);
+
     DiaryDetailResponseDTO requestDiaryDetails(long diaryId);
 
     void deleteDiary(long diaryId);

--- a/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
@@ -37,6 +37,15 @@ public class DiaryServiceImpl implements DiaryService {
         diaryRepository.updateDiary(diaryData);
     }
 
+    @Override
+    public void updateDiary(DiaryEditRequestDTOv2 diaryEditRequestDTOv2) {
+        diaryRepository.updateDiaryV2(diaryEditRequestDTOv2);
+
+        Long diaryId = diaryEditRequestDTOv2.getId();
+        teamDiaryRepository.insertTeamDiaryV2(diaryId, diaryEditRequestDTOv2.getAddedTeamIds());
+        teamDiaryRepository.deleteTeamDiaryV2(diaryId, diaryEditRequestDTOv2.getRemovedTeamIds());
+    }
+
     // 선택한 다이어리 상세 정보 요청
     @Override
     public DiaryDetailResponseDTO requestDiaryDetails(long diaryId) {


### PR DESCRIPTION
### PR 설명

일기 공유 API v2의 핵심 처리 로직을 담당할 `DiaryService`의 `updateDiary(DiaryEditRequestDTOv2 dto)` 메서드를 정의하고 구현했습니다.

이 메서드는 다음 작업을 한 번의 요청으로 처리합니다

1. 일기 제목, 내용, 날짜 수정
2. 추가된 팀 목록에 대해 공유 등록
3. 제거된 팀 목록에 대해 공유 취소


### 변경 목적 (v2 도입 이유)

- 기존에는 일기 수정 / 팀 공유 / 공유 취소를 각각 별도의 API로 호출해야 했음  
- 하나의 요청으로 세 작업을 처리할 수 있도록 Service에서 통합 로직 구성  
- 트랜잭션 처리 단위로도 효율적이며, 프론트엔드 요청 간소화 효과


### 작업 계획 (전체 체크리스트)

- [x] 1. `DiaryEditRequestDTOv2` 생성  
- [x] 2. Mapper 및 Repository 구현  
- [x] 3. `updateDiaryV2`, `deleteTeamDiaryV2`, `insertTeamDiaryV2` 구현 완료  
- [x] 4. Service 메서드 정의  
- [x] 5. ServiceImpl에서 다음 통합 처리 로직 구현  
  - [x] `diaryRepository.updateDiaryV2(...)`  
  - [x] `teamDiaryRepository.insertTeamDiaryV2(...)`  
  - [x] `teamDiaryRepository.deleteTeamDiaryV2(...)`  
- [ ] 6. Controller에서 통합 API 생성 (다음 단계)


### 이번 PR 범위

- ✅ `DiaryService` 인터페이스에 `updateDiary(DiaryEditRequestDTOv2)` 메서드 추가  
- ✅ `DiaryServiceImpl`에서 v2 통합 처리 로직 구현  
  - 다이어리 정보 수정 + 팀 공유 추가 + 팀 공유 취소