### PR TITLE
[backend] feat: 일기 수정 v2 API 컨트롤러 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/DiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/DiaryController.java
@@ -39,6 +39,14 @@ public class DiaryController {
         return ResponseEntity.ok("diary edited.");
     }
 
+    @Operation(summary = "일기 수정")
+    @PutMapping("/v2/diaries/edit/{id}")
+    public ResponseEntity<String> updateDiary(@RequestBody DiaryEditRequestDTOv2 diaryEditRequestDTOv2) {
+        diaryService.updateDiary(diaryEditRequestDTOv2);
+
+        return ResponseEntity.ok("diary edited.");
+    }
+
     @Operation(summary = "일기 삭제")
     @DeleteMapping("/diaries/{id}")
     public HashMap<String, String> deleteDiary(@PathVariable(required = true) long id, @RequestParam(defaultValue = "succ") String succMsg) {


### PR DESCRIPTION
### PR 설명

프론트엔드에서 일기 수정 및 공유 팀 변경을 한 번의 요청으로 처리할 수 있도록,  
v2 API 엔드포인트를 `DiaryController`에 추가했습니다.

- `@PutMapping("/v2/diaries/edit/{id}")` 엔드포인트 정의  
- 요청 본문은 `DiaryEditRequestDTOv2`로 받고,  
- 내부적으로 `diaryService.updateDiary(DiaryEditRequestDTOv2)` 호출하여 통합 처리


### 변경 목적 (v2 도입 이유)

- 기존 API 구조에서는 일기 수정과 팀 공유/취소를 각각 따로 호출해야 했음  
- 클라이언트 요청 수를 줄이고 트랜잭션 단위로 안정적으로 처리하기 위해  
- 하나의 API에서 일기 정보 수정 + 팀 공유 추가/삭제가 모두 가능하도록 개선함


### 작업 계획 (전체 체크리스트)

- [x] 1. `DiaryEditRequestDTOv2` 생성  
- [x] 2. Mapper XML 및 Mapper 인터페이스 작성  
- [x] 3. Repository 정의 및 구현 (MyBatis 연결)  
- [x] 4. Service 메서드 구현 (`updateDiaryV2`, `insert/deleteTeamDiaryV2`)  
- [x] 5. Controller에 v2 API 엔드포인트 추가  


### 이번 PR 범위

- ✅ `DiaryController`에 `@PutMapping("/v2/diaries/edit/{id}")` API 추가  
- ✅ `DiaryEditRequestDTOv2` 요청을 받아 `diaryService.updateDiary(...)` 호출  
