### PR TITLE
[backend] refactor: 일기 수정 v2 API에서 PathVariable 제거 및 요청 형식 변경

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/DiaryController.java
+++ b/backend/src/main/java/com/example/demo/controller/DiaryController.java
@@ -40,7 +40,7 @@ public class DiaryController {
     }
 
     @Operation(summary = "일기 수정")
-    @PutMapping("/v2/diaries/edit/{id}")
+    @PutMapping("/v2/diaries/edit")
     public ResponseEntity<String> updateDiary(@RequestBody DiaryEditRequestDTOv2 diaryEditRequestDTOv2) {
         diaryService.updateDiary(diaryEditRequestDTOv2);
 

--- a/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
@@ -20,7 +20,7 @@ public interface TeamDiaryMapper {
     // 팀 일기 삭제 (공유 해제)
     void deleteTeamDiary(long diaryId, long teamId);
 
-    void deleteTeamDiary(Long diaryId, List<Long> teamIds);
+    void deleteTeamDiaryV2(Long diaryId, List<Long> teamIds);
 
     // 현재 팀에 공유된 일기 리스트 요청
     List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
@@ -30,12 +30,11 @@ public class TeamDiaryRepositoryImplMyBatis implements TeamDiaryRepository {
     @Override
     public void deleteTeamDiary(long diaryId, long teamId) {
         teamDiaryMapper.deleteTeamDiary(diaryId, teamId);
-
     }
 
     @Override
     public void deleteTeamDiaryV2(Long diaryId, List<Long> teamIds) {
-        teamDiaryMapper.deleteTeamDiary(diaryId, teamIds);
+        teamDiaryMapper.deleteTeamDiaryV2(diaryId, teamIds);
     }
 
     @Override

--- a/backend/src/main/resources/mapper/diary.xml
+++ b/backend/src/main/resources/mapper/diary.xml
@@ -23,7 +23,7 @@
     <update id="updateDiaryV2" parameterType="com.example.demo.dto.DiaryEditRequestDTOv2">
         UPDATE diaries
         SET written_date = #{writtenDate},
-            diary_title  = #{diaryTitle},
+            diary_title  = #{title},
             details      = #{details}
         WHERE id = #{id};
     </update>


### PR DESCRIPTION
- 기존 /v2/diaries/edit/{id} → /v2/diaries/edit 로 수정

- id를 @RequestBody에 포함하는 방식으로 변경하여 API 일관성 확보