### PR TITLE
[backend] feat: diaryId가 특정 값인 일기를 삭제하는 쿼리 작성

### DIFF
--- a/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
+++ b/backend/src/main/java/com/example/demo/mapper/TeamDiaryMapper.java
@@ -22,6 +22,9 @@ public interface TeamDiaryMapper {
 
     void deleteTeamDiaryV2(Long diaryId, List<Long> teamIds);
 
+    // 일기 id에 따라 teamDiary 삭제
+    void deleteByDiaryId(Long diaryId);
+
     // 현재 팀에 공유된 일기 리스트 요청
     List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
 

--- a/backend/src/main/resources/mapper/teamDiary.xml
+++ b/backend/src/main/resources/mapper/teamDiary.xml
@@ -31,6 +31,12 @@
         </foreach>
     </delete>
 
+    <delete id="deleteByDiaryId">
+        DELETE
+        FROM team_diary
+        WHERE id = #{diaryId};
+    </delete>
+
     <select id="requestTeamDiaryList" resultType="com.example.demo.response.TeamDiaryListResponse">
         SELECT d.id, u.first_name, u.last_name, u.initial, u.color, d.written_date, d.diary_title
         FROM team_diary td


### PR DESCRIPTION
### PR 설명

일기를 삭제할 때 해당 일기와 연결된 팀 공유 데이터(`team_diary` 테이블)도 함께 삭제하기 위해,  
`diaryId`가 특정 값인 경우 `team_diary` 데이터를 삭제하는 쿼리를 추가했습니다.

### 변경 목적

- 일기가 삭제되어도 `team_diary` 테이블에 관련 데이터가 남아있는 문제 방지  
- 데이터 무결성을 유지하고, orphan record가 남지 않도록 사전 정리  
- Controller 또는 Service에서 일기 삭제 전 호출하여 연결된 공유 정보 제거


### 작업 내용

- `TeamDiaryMapper.xml`에 `deleteByDiaryId` 쿼리 추가  
  ```sql
  DELETE FROM team_diary WHERE diary_id = #{diaryId}