### PR TITLE
[backend] feat: repository에 deleteByDiaryId 구현

### DIFF
--- a/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/TeamDiaryRepository.java
@@ -15,6 +15,8 @@ public interface TeamDiaryRepository {
 
     void deleteTeamDiaryV2(Long diaryId, List<Long> teamIds);
 
+    void deleteByDiaryId(Long diaryId);
+
     List<TeamDiaryListResponse> requestTeamDiaryList(long teamId);
 
     List<SharedTeamsResponse> requestSharedTeams(long diaryId);

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/TeamDiaryRepositoryImplJpa.java
@@ -29,6 +29,11 @@ public class TeamDiaryRepositoryImplJpa implements TeamDiaryRepository {
     }
 
     @Override
+    public void deleteByDiaryId(Long diaryId) {
+
+    }
+
+    @Override
     public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
         return null;
     }

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/TeamDiaryRepositoryImplMyBatis.java
@@ -38,6 +38,11 @@ public class TeamDiaryRepositoryImplMyBatis implements TeamDiaryRepository {
     }
 
     @Override
+    public void deleteByDiaryId(Long diaryId) {
+        teamDiaryMapper.deleteByDiaryId(diaryId);
+    }
+
+    @Override
     public List<TeamDiaryListResponse> requestTeamDiaryList(long teamId) {
         return teamDiaryMapper.requestTeamDiaryList(teamId);
     }


### PR DESCRIPTION
### PR 설명

일기 삭제 시 해당 일기와 연결된 팀 공유 정보(`team_diary`)도 함께 삭제하기 위해,  
`deleteByDiaryId(Long diaryId)` 메서드를 Repository 계층에 구현했습니다.

- 인터페이스 정의: `TeamDiaryRepository`  
- 구현 클래스:  
  - `TeamDiaryRepositoryImplMyBatis`: 실제 `mapper.deleteByDiaryId(...)` 호출  
  - `TeamDiaryRepositoryImplJpa`: 현재 비워둔 상태


### 변경 목적

- 일기를 삭제할 때 연관된 공유 데이터를 명시적으로 삭제하여 데이터 무결성 유지  
- `Service` 또는 `Controller`에서 일기 삭제 전에 호출 가능하도록 Repository에 메서드 구현  


### 작업 내용

- `TeamDiaryRepository` 인터페이스에 `deleteByDiaryId(Long diaryId)` 추가  
- `TeamDiaryRepositoryImplMyBatis`에서 Mapper 메서드 호출 구현  
- `TeamDiaryRepositoryImplJpa`는 현재 구현 비워둠
