### PR TITLE
[backend] feat: 일기 삭제 시 공유된 팀 정보도 함께 삭제하도록 Service 로직 수정

### DIFF
--- a/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
@@ -59,6 +59,7 @@ public class DiaryServiceImpl implements DiaryService {
     @Override
     public void deleteDiary(long diaryId) {
         diaryRepository.deleteDiary(diaryId);
+        teamDiaryRepository.deleteByDiaryId(diaryId);
     }
 
     // 사용자가 포함된 모든 그룹의 일기 정보 요청


### PR DESCRIPTION
### PR 설명

일기 삭제 시 해당 일기와 연결된 팀 공유 정보(`team_diary`)가 함께 삭제되도록  
`DiaryServiceImpl`의 `deleteDiary(...)` 로직을 수정했습니다.

- 기존에는 단순히 `diaryRepository.deleteDiary(id)`만 호출했지만,  
- 이제는 그 전에 `teamDiaryRepository.deleteByDiaryId(id)`를 먼저 호출하여 공유된 데이터 제거

### 변경 목적

- 일기가 삭제되어도 `team_diary` 테이블에 남아있는 공유 데이터로 인해 무결성 문제가 발생할 수 있음  
- 서비스 레벨에서 해당 일기와 연결된 모든 공유 정보를 먼저 삭제하도록 순서를 명확히 구성  


### 작업 내용

- `DiaryServiceImpl`의 `deleteDiary(long id)` 메서드 수정  
  ```java
  teamDiaryRepository.deleteByDiaryId(id);  
  diaryRepository.deleteDiary(id);
