### PR TITLE
[backend] fix: deleteByDiaryId 쿼리에서 속성 id -> diary_id로 수정

### DIFF
--- a/backend/src/main/resources/mapper/teamDiary.xml
+++ b/backend/src/main/resources/mapper/teamDiary.xml
@@ -34,7 +34,7 @@
     <delete id="deleteByDiaryId">
         DELETE
         FROM team_diary
-        WHERE id = #{diaryId};
+        WHERE diary_id = #{diaryId};
     </delete>
 
     <select id="requestTeamDiaryList" resultType="com.example.demo.response.TeamDiaryListResponse">


### PR DESCRIPTION
### PR 설명

`team_diary` 테이블에서 일기 ID 기준으로 데이터를 삭제하는 `deleteByDiaryId` 쿼리의 조건절에서  
잘못된 컬럼명(`id`)을 올바른 컬럼명(`diary_id`)으로 수정했습니다.
