### PR TITLE
[frontend] refactor: POST /v2/diaries로 일기 작성 요청 경로 변경 및 API 통합

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -11,10 +11,12 @@ export async function fetchAllDiaries(userId) {
 
     if (!res.ok) {
       const errorData = await res.json().catch(() => ({}));
-      throw new Error(errorData.message || '전체 일기 목록을 불러오지 못했습니다.');
+      throw new Error(
+        errorData.message || '전체 일기 목록을 불러오지 못했습니다.'
+      );
     }
     const data = await res.json();
-    console.log("data: ", data);
+    console.log('data: ', data);
 
     return data.data;
   } catch (error) {
@@ -75,7 +77,9 @@ export async function fetchDiaryDetail(diaryId) {
 
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(errorData.message || '일기 상세 정보를 불러오지 못했습니다.');
+      throw new Error(
+        errorData.message || '일기 상세 정보를 불러오지 못했습니다.'
+      );
     }
 
     const data = await response.json();
@@ -124,6 +128,25 @@ export async function deleteDiary(diaryId) {
       throw new Error(errorData.message || '일기 삭제에 실패했습니다.');
     }
     return true;
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function writeDiary(diaryData) {
+  try {
+    const response = await fetch(`${BASE_URL}/v2/diaries`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(diaryData),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || '일기 작성에 실패했습니다.');
+    }
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
### 변경 사항

- 기존의 `createDiary()` 함수를 제거하고 새로운 `writeDiary()` 함수로 일기 작성 API 요청을 `/v2/diaries` 경로로 통합
- 요청 데이터 구조를 백엔드 v2 API 형식에 맞춰 아래와 같이 수정:
  - `writerId`, `writtenDate`, `title`, `details`, `sharedTeamList` 포함
- 필요 없는 import 및 변수 정리

### 수정 파일

- `frontend/src/api/diary.js`
  - `writeDiary()` 함수 추가
  - 불필요한 코드 포맷팅 정리
- `frontend/src/views/diaries/writeDiaryPage.vue`
  - `createDiary()` → `writeDiary()`로 변경
  - request payload 구조 변경
