### PR TITLE
[frontend] refactor: PUT /v2/diaries/edit로 일기 수정 요청 경로 변경 및 공유 수정 로직 통합

### DIFF
--- a/frontend/src/api/diary.js
+++ b/frontend/src/api/diary.js
@@ -151,3 +151,22 @@ export async function writeDiary(diaryData) {
     throw error;
   }
 }
+
+export async function editDiary(diaryData) {
+  try {
+    const response = await fetch(`${BASE_URL}/v2/diaries/edit`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(diaryData),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || '일기 수정에 실패했습니다.');
+    }
+  } catch (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
### 변경 내용

- 기존 `updateDiary()` 함수 제거 및 `editDiary()` 함수로 수정 요청 API 통합
- 일기 수정 시 호출되는 API를 `/v2/diaries/edit`로 변경
- 수정 시 공유된 팀 목록의 변화(추가/삭제)를 감지하여, 함께 서버에 전달하는 구조로 리팩토링
- 이전에 존재하던 공유 추가/삭제 API 호출 방식 제거 (for-loop 방식 삭제)
- `requestEditedTeamList()` 함수 제거 및 팀 리스트 비교 함수는 `findEditedTeamList()`로 대체

### 변경된 파일

- `frontend/src/api/diary.js`
  - `editDiary()` 함수 추가
- `frontend/src/views/diaries/writeDiaryPage.vue`
  - API 변경 대응
  - 공유 팀 수정 비교 및 요청 데이터 구조 재정비
  - 공유팀 수정 방식 단일 API 통합 처리로 리팩토링

### 리팩토링 이유

- 프론트에서 공유 팀 추가/삭제를 별도 API로 호출하는 방식은 불필요한 요청 증가로 이어짐
- 서버에서 일기 수정과 동시에 공유 상태를 반영하는 API 구조(`/v2/diaries/edit`)에 맞춰 변경
- 코드 간결화 및 중복 로직 제거 목적