### PR TITLE
[test] refactor: 일기 작성 관련 인터셉트 API를 통합된 v2 엔드포인트로 수정

### DIFF
--- a/frontend/cypress/e2e/login_and_write_diary.cy.js
+++ b/frontend/cypress/e2e/login_and_write_diary.cy.js
@@ -14,9 +14,7 @@ describe('일기 작성 시나리오', () => {
 
   it('일기 작성', () => {
     // 일기 작성 API 인터셉트 설정
-    cy.intercept('POST', '/diaries').as('createDiary');
-    cy.intercept('POST', '/teamDiaries').as('shareDiary');
-    cy.intercept('GET', '/diaries/findDiaryId*').as('findDiaryId');
+    cy.intercept('POST', '/v2/diaries').as('createDiary');
 
     // 일기 작성 버튼 클릭
     cy.contains('Write diary').click();


### PR DESCRIPTION
### 변경 내용

기존에는 일기 작성 시 다음과 같이 여러 개의 API 인터셉트를 사용하고 있었습니다:

- `POST /diaries`
- `POST /teamDiaries`
- `GET /diaries/findDiaryId*`

새로운 API 구조에서는 이 요청들을 하나로 통합한 `POST /v2/diaries` 엔드포인트를 사용함에 따라, 이에 맞춰 Cypress 테스트 코드의 인터셉트 설정을 다음과 같이 수정했습니다

```diff
- cy.intercept('POST', '/diaries').as('createDiary');
- cy.intercept('POST', '/teamDiaries').as('shareDiary');
- cy.intercept('GET', '/diaries/findDiaryId*').as('findDiaryId');
+ cy.intercept('POST', '/v2/diaries').as('createDiary');