### PR TITLE
[test] refactor: 로그인 절차를 support/commands.js의 cy.login()으로 모듈화

### DIFF
--- a/frontend/cypress/e2e/login_and_write_diary.cy.js
+++ b/frontend/cypress/e2e/login_and_write_diary.cy.js
@@ -1,15 +1,8 @@
+import '../support/commands';
+
 describe('일기 작성 시나리오', () => {
   beforeEach(() => {
-    // BaseURL을 사용하여 로그인 페이지 방문
-    cy.visit('/');
-    cy.url().should('include', '/logIn');
-
-    cy.get('input[type="email"]').type(Cypress.env('TEST_EMAIL'));
-    cy.get('input[type="password"]').type(Cypress.env('TEST_PASSWORD'));
-
-    cy.get('button[type="button"]').click();
-
-    cy.url().should('include', '/main');
+    cy.login();
   });
 
   it('일기 작성', () => {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -1,0 +1,11 @@
+Cypress.Commands.add('login', () => {
+    cy.visit('/');
+    cy.url().should('include', '/logIn');
+
+    cy.get('input[type="email"]').type(Cypress.env('TEST_EMAIL'));
+    cy.get('input[type="password"]').type(Cypress.env('TEST_PASSWORD'));
+
+    cy.get('button[type="button"]').click();
+
+    cy.url().should('include', '/main');
+})


### PR DESCRIPTION
### 변경 내용

- 매 테스트마다 반복될 로그인 코드를 Cypress 커스텀 커맨드로 추출했습니다.
- `cypress/support/commands.js`에 `cy.login()` 명령을 정의하여 재사용 가능하도록 하였습니다.