### PR TITLE
[test] feat: 일기 수정 E2E 테스트 시나리오 추가

### DIFF
--- a/frontend/cypress/e2e/login_and_write_diary.cy.js
+++ b/frontend/cypress/e2e/login_and_write_diary.cy.js
@@ -55,4 +55,51 @@ describe('일기 작성 시나리오', () => {
     cy.url().should('include', '/main');
     cy.contains('test').should('not.exist');
   });
+
+  it('일기 수정', () => {
+    // 다이어리 리스트가 로드될 때까지 대기
+    cy.get('table tbody tr').should('have.length.greaterThan', 0);
+
+    // 첫 번째 다이어리 제목 클릭
+    cy.get('table tbody tr').eq(0).find('td h6 a').click();
+
+    // 상세 페이지 URL 확인
+    cy.url().should('include', '/diaryDetail?diary=');
+
+    // 수정 버튼 클릭
+    cy.contains('수정').click();
+
+    // 수정 페이지 url 확인
+    cy.url().should('include', '/editDiary?diaryId=');
+
+    // 일기 수정
+    cy.get('input[type="date"]').type('2025-08-11');
+    cy.get('input[placeholder="제목').clear().type('Edited title');
+
+    cy.get('#navbarDropdownMenuLink2').click();
+    cy.get('.dropdown-menu .dropdown-item').first().click();
+    cy.get('#recipient_input_list .badge').first().within(() => {
+      cy.get('a').click();
+    });
+    cy.get('textarea[name="message"]').clear().type('edited details');
+
+     // 일기 수정 API 인터셉트 설정
+     cy.intercept('PUT', '/v2/diaries/edit').as('editDiary');
+
+     // edit 버튼 클릭
+     cy.get('button').contains('edite').click();
+
+     // API 응답 대기
+     cy.wait('@editDiary');
+
+     // 일기 detail 페이지로 갔는지 확인
+     cy.url().should('include', '/diaryDetail?diary=');
+     
+     // 수정된 일기 내용이 제대로 반영되었는지 확인
+     cy.contains('Edited title').should('be.visible');
+     cy.contains('edited details').should('be.visible');
+     
+     // 수정된 날짜가 제대로 표시되는지 확인 (날짜 형식에 따라 조정 필요)
+     cy.contains('2025-08-11').should('be.visible');
+  })
 });


### PR DESCRIPTION
## 주요 변경 사항
- 첫 번째 다이어리 항목을 클릭하여 상세 페이지로 이동 후 수정 버튼 클릭
- 수정 페이지에서:
  - 날짜 변경
  - 제목 수정
  - 팀 추가 및 기존 팀 삭제
  - 본문 내용 수정
- 수정 API(`PUT /v2/diaries/edit`) 인터셉트 및 응답 대기 처리
- 수정 완료 후 상세 페이지에서 변경 내용(제목, 내용, 날짜) 검증

## 테스트 시나리오
1. 메인 페이지에서 첫 번째 다이어리 클릭 → 상세 페이지 이동
2. 수정 버튼 클릭 → 수정 페이지 이동
3. 날짜, 제목, 팀, 내용 수정
4. 수정 요청 전송(`PUT /v2/diaries/edit`)
5. 수정된 내용이 상세 페이지에 반영되었는지 확인