### PR TITLE
[test] feat: 회원 정보 수정 E2E 시나리오에서 PUT /users/:id API 인터셉트 및 응답 대기 로직 추가

### DIFF
--- a/frontend/cypress/e2e/user.cy.js
+++ b/frontend/cypress/e2e/user.cy.js
@@ -39,7 +39,7 @@ describe('사용자 관련 시나리오', () => {
     cy.url().should('include', '/userInfoEdit');
 
     // 데이터 변경
-    cy.get('input[placeholder="First Name"]').clear().type('FistName(edited)');
+    cy.get('input[placeholder="First Name"]').clear().type('FirstName(edited)');
     cy.get('input[placeholder="Last Name"]').clear().type('LastName(edited)');
     cy.get('input[placeholder="Email Address"]')
       .clear()
@@ -50,8 +50,15 @@ describe('사용자 관련 시나리오', () => {
       .trigger('input') // v-model이 반응하도록 input 이벤트 발생
       .should('have.value', '#ff0000');
 
+    // 회원정보 수정 API 인터셉트 설정
+    cy.intercept('PUT', /\/users\/\d+/).as('updateUser');
+
     // 저장 버튼 클릭
     cy.contains('button', 'Save').click();
+    
+    // API 응답 대기
+    cy.wait('@updateUser');
+
     cy.url().should('include', '/userInfo');
 
     // 데이터 복원
@@ -59,7 +66,7 @@ describe('사용자 관련 시나리오', () => {
     cy.url().should('include', '/userInfoEdit');
 
     cy.get('input');
-    cy.get('input[placeholder="First Name"]').clear().type('FistName');
+    cy.get('input[placeholder="First Name"]').clear().type('FirstName');
     cy.get('input[placeholder="Last Name"]').clear().type('LastName');
     cy.get('input[placeholder="Email Address"]').clear().type('test');
     cy.get('input[placeholder="Password"]').clear().type('test');


### PR DESCRIPTION
## 주요 변경 사항
- 회원 정보 수정 시 `PUT /users/:id` 요청을 인터셉트(`cy.intercept`)하여 별칭 `@updateUser`로 지정
- 저장 버튼 클릭 후 `cy.wait('@updateUser')`를 통해 API 응답 완료 시점까지 대기
- First Name 필드의 오타(`FistName`) 수정 → `FirstName`