### PR TITLE
[backend] fix: DiaryServiceImpl.updateDiary에서 added/removedTeamIds가 비어있을 경우 팀 연동 쿼리 실행하지 않도록 수정

### DIFF
--- a/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/DiaryServiceImpl.java
@@ -42,8 +42,13 @@ public class DiaryServiceImpl implements DiaryService {
         diaryRepository.updateDiaryV2(diaryEditRequestDTOv2);
 
         Long diaryId = diaryEditRequestDTOv2.getId();
-        teamDiaryRepository.insertTeamDiaryV2(diaryId, diaryEditRequestDTOv2.getAddedTeamIds());
-        teamDiaryRepository.deleteTeamDiaryV2(diaryId, diaryEditRequestDTOv2.getRemovedTeamIds());
+        if (!diaryEditRequestDTOv2.getAddedTeamIds().isEmpty()) {
+            teamDiaryRepository.insertTeamDiaryV2(diaryId, diaryEditRequestDTOv2.getAddedTeamIds());
+        }
+
+        if (!diaryEditRequestDTOv2.getRemovedTeamIds().isEmpty()) {
+            teamDiaryRepository.deleteTeamDiaryV2(diaryId, diaryEditRequestDTOv2.getRemovedTeamIds());
+        }
     }
 
     // 선택한 다이어리 상세 정보 요청


### PR DESCRIPTION
## 개요
- 일기 수정 시 `addedTeamIds` 또는 `removedTeamIds`가 비어있는 경우에도 팀 연동 쿼리(insert/delete)가 실행되어
  MySQL 문법 오류(SQLSyntaxErrorException)가 발생하는 문제를 해결했습니다.

## 주요 변경 사항
- `DiaryServiceImpl.updateDiary(DiaryEditRequestDTOv2)`에서
  - addedTeamIds가 비어있으면 insert 호출 생략
  - removedTeamIds가 비어있으면 delete 호출 생략

## 기대 효과
- 빈 리스트로 인한 불필요한 SQL 실행 방지
- MyBatis `<foreach>`에서 값이 없을 때 발생하는 SQL 문법 오류 예방
