### PR TITLE
[backend] feat: email로 사용자 ID 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/UserController.java
+++ b/backend/src/main/java/com/example/demo/controller/UserController.java
@@ -15,6 +15,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 public class UserController {
+    // todo: 구현체 참조 수정
     private final UserServiceImpl userServiceImpl;
     private final UserService userService;
 
@@ -77,5 +78,12 @@ public class UserController {
         result.put("result", "success");
         result.put("data", data);
         return result;
+    }
+
+    @Operation(summary = "사용자 이메일로 id 겁색")
+    @GetMapping("/users/{email}")
+    public ResponseEntity<Long> findUserIdByEmail(@PathVariable String email) {
+        Long userId = userService.findUserIdByEmail(email);
+        return ResponseEntity.ok(userId);
     }
 }

--- a/backend/src/main/java/com/example/demo/mapper/UserMapper.java
+++ b/backend/src/main/java/com/example/demo/mapper/UserMapper.java
@@ -30,4 +30,6 @@ public interface UserMapper {
     UserModel logIn(LogInRequestDTO user);
 
     UserModel getUser(@Param("userId") long userId);
+
+    Long findUserIdByEmail(String email);
 }

--- a/backend/src/main/java/com/example/demo/repository/inter/UserRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/inter/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository {
     UserResponseDTO getUser(long userId);
 
     void insertUser(SignupRequestDTO signupRequestDTO);
+
+    Long findUserIdByEmail(String email);
 }

--- a/backend/src/main/java/com/example/demo/repository/jpaImpl/UserRepositoryImplJpa.java
+++ b/backend/src/main/java/com/example/demo/repository/jpaImpl/UserRepositoryImplJpa.java
@@ -23,4 +23,9 @@ public class UserRepositoryImplJpa implements UserRepository {
     public void insertUser(SignupRequestDTO signupRequestDTO) {
 
     }
+
+    @Override
+    public Long findUserIdByEmail(String email) {
+        return null;
+    }
 }

--- a/backend/src/main/java/com/example/demo/repository/mybatisImpl/UserRepositoryImplMybatis.java
+++ b/backend/src/main/java/com/example/demo/repository/mybatisImpl/UserRepositoryImplMybatis.java
@@ -36,4 +36,9 @@ public class UserRepositoryImplMybatis implements UserRepository {
     public void insertUser(SignupRequestDTO signupRequestDTO) {
         userMapper.insertUser(signupRequestDTO);
     }
+
+    @Override
+    public Long findUserIdByEmail(String email) {
+        return userMapper.findUserIdByEmail(email);
+    }
 }

--- a/backend/src/main/java/com/example/demo/service/UserService.java
+++ b/backend/src/main/java/com/example/demo/service/UserService.java
@@ -17,4 +17,6 @@ public interface UserService {
     List<UserModel> userEmailSearchModel(String searchWord);
 
     LoginResponseDTO logIn(LogInRequestDTO user);
+
+    Long findUserIdByEmail(String email);
 }

--- a/backend/src/main/java/com/example/demo/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/example/demo/service/UserServiceImpl.java
@@ -49,4 +49,9 @@ public class UserServiceImpl implements UserService {
     public LoginResponseDTO logIn(LogInRequestDTO user) {
         return userRepository.login(user);
     }
+
+    @Override
+    public Long findUserIdByEmail(String email) {
+        return userMapper.findUserIdByEmail(email);
+    }
 }


### PR DESCRIPTION
## 개요
E2E 테스트 시 회원가입 후 생성된 사용자를 삭제할 때, ID 조회를 위해 email 기반 사용자 ID 검색 API를 추가했습니다.

## 주요 변경 사항
- UserController
  - GET /users/{email} 엔드포인트 추가
  - email을 PathVariable로 받아 해당 사용자의 ID를 반환
- UserService / UserServiceImpl
  - findUserIdByEmail 메서드 추가
- UserRepository / MyBatis 구현체
  - findUserIdByEmail 메서드 추가 및 UserMapper 연동
- UserMapper 및 MyBatis XML
  - email로 ID를 조회하는 쿼리 추가