### PR TITLE
[backend] refactor: 사용자 ID 조회 API를 PathVariable → RequestParam 방식으로 변경

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/UserController.java
+++ b/backend/src/main/java/com/example/demo/controller/UserController.java
@@ -81,8 +81,8 @@ public class UserController {
     }
 
     @Operation(summary = "사용자 이메일로 id 겁색")
-    @GetMapping("/users/{email}")
-    public ResponseEntity<Long> findUserIdByEmail(@PathVariable String email) {
+    @GetMapping("/users/search")
+    public ResponseEntity<Long> findUserIdByEmail(@RequestParam String email) {
         Long userId = userService.findUserIdByEmail(email);
         return ResponseEntity.ok(userId);
     }


### PR DESCRIPTION
## 변경 사항
- `/users/{email}` 형식의 PathVariable 기반 API를 `/users/search?email=` 형식의 RequestParam 기반 API로 변경
- 이메일 주소 내 `@` 등 특수문자 인코딩 문제를 방지하고, 요청 가독성을 향상

## 변경 이유
- PathVariable 사용 시 이메일 특수문자 인코딩 문제 발생 가능성 제거
- API 호출 시 더 명시적인 파라미터 전달 구조로 변경

## 테스트
- 로컬 환경에서 `/users/search?email=test@example.com` 호출 시 정상적으로 ID 반환 확인