### PR TITLE
[test] feat: 회원가입 E2E 테스트에 사용자 ID 조회·삭제 로직 추가

### DIFF
--- a/frontend/cypress/e2e/user.cy.js
+++ b/frontend/cypress/e2e/user.cy.js
@@ -15,12 +15,136 @@ describe('사용자 관련 시나리오', () => {
     cy.get('input[placeholder="Last Name"]').type('LastName');
     cy.get('input[placeholder="Email Address"]').type('test@gmail.com');
     cy.get('input[placeholder="Password"]').type('password');
-    cy.get('input[name="favcolor').type('#0011FF');
+    cy.get('input[name="favcolor"]').type('#0011FF');
 
     cy.contains('button', 'Sign up').click();
 
-    // API 응답 대기
-    cy.wait('@signUp');
+    // API 응답 대기 및 사용자 ID 추출
+    cy.wait('@signUp').then((interception) => {
+      // 회원가입 API 응답에서 사용자 ID 추출
+      if (interception.response && interception.response.body) {
+        cy.log(`전체 응답 본문: ${JSON.stringify(interception.response.body)}`);
+        
+        // 다양한 응답 구조에서 사용자 ID 추출 시도
+        let createdUserId = null;
+        
+        // 1. 직접 id 또는 userId 필드 확인
+        if (interception.response.body.id) {
+          createdUserId = interception.response.body.id;
+        } else if (interception.response.body.userId) {
+          createdUserId = interception.response.body.userId;
+        }
+        // 2. data 객체 내부 확인
+        else if (interception.response.body.data && interception.response.body.data.id) {
+          createdUserId = interception.response.body.data.id;
+        }
+        // 3. result 객체 내부 확인
+        else if (interception.response.body.result && interception.response.body.result.id) {
+          createdUserId = interception.response.body.result.id;
+        }
+        
+        // 4. 이메일로 사용자 ID 조회 (새로운 백엔드 API 사용)
+        if (!createdUserId) {
+          cy.log('이메일로 사용자 ID 조회 시도...');
+          
+          // 방법 1: 직접 이메일 경로로 조회
+          cy.request({
+            method: 'GET',
+            url: `http://localhost:8080/users/search?email=test%40gmail.com`,
+            failOnStatusCode: false
+          }).then((userResponse) => {
+            cy.log(`이메일 조회 응답 상태: ${userResponse.status}`);
+            cy.log(`이메일 조회 응답 본문: ${JSON.stringify(userResponse.body)}`);
+            
+            if (userResponse.status === 200 && userResponse.body) {
+              createdUserId = userResponse.body;
+              cy.log(`이메일로 찾은 사용자 ID: ${createdUserId}`);
+              
+              // 사용자 삭제 실행
+              if (createdUserId) {
+                cy.log(`테스트 완료 후 사용자 ID ${createdUserId} 삭제 시작`);
+                
+                cy.request({
+                  method: 'DELETE',
+                  url: `http://localhost:8080/users/${createdUserId}`,
+                  failOnStatusCode: false
+                }).then((deleteResponse) => {
+                  if (deleteResponse.status === 200) {
+                    cy.log(`사용자 ID ${createdUserId} 삭제 성공`);
+                  } else {
+                    cy.log(`사용자 ID ${createdUserId} 삭제 실패: ${deleteResponse.status}`);
+                  }
+                });
+              }
+            } else if (userResponse.status === 400) {
+              cy.log('400 에러 발생. 다른 방법으로 시도...');
+              
+              // 방법 2: 쿼리 파라미터로 이메일 전달
+              cy.request({
+                method: 'GET',
+                url: 'http://localhost:8080/users',
+                qs: { email: 'test@gmail.com' },
+                failOnStatusCode: false
+              }).then((userResponse2) => {
+                cy.log(`쿼리 파라미터 조회 응답 상태: ${userResponse2.status}`);
+                cy.log(`쿼리 파라미터 조회 응답 본문: ${JSON.stringify(userResponse2.body)}`);
+                
+                if (userResponse2.status === 200 && userResponse2.body) {
+                  if (Array.isArray(userResponse2.body)) {
+                    const user = userResponse2.body.find(u => u.email === 'test@gmail.com');
+                    if (user && user.id) {
+                      createdUserId = user.id;
+                      cy.log(`쿼리 파라미터로 찾은 사용자 ID: ${createdUserId}`);
+                      
+                      // 사용자 삭제 실행
+                      if (createdUserId) {
+                        cy.log(`테스트 완료 후 사용자 ID ${createdUserId} 삭제 시작`);
+                        
+                        cy.request({
+                          method: 'DELETE',
+                          url: `http://localhost:8080/users/${createdUserId}`,
+                          failOnStatusCode: false
+                        }).then((deleteResponse) => {
+                          if (deleteResponse.status === 200) {
+                            cy.log(`사용자 ID ${createdUserId} 삭제 성공`);
+                          } else {
+                            cy.log(`사용자 ID ${createdUserId} 삭제 실패: ${deleteResponse.status}`);
+                          }
+                        });
+                      }
+                    }
+                  }
+                }
+              });
+            } else {
+              cy.log(`사용자 ID 조회 실패: ${userResponse.status}`);
+            }
+          });
+        }
+        
+        cy.log(`추출된 사용자 ID: ${createdUserId}`);
+        
+        // 회원가입 테스트 완료 후 바로 사용자 삭제 (이메일 조회로 ID를 찾지 못한 경우)
+        if (createdUserId && !createdUserId.toString().includes('@')) {
+          cy.log(`테스트 완료 후 사용자 ID ${createdUserId} 삭제 시작`);
+          
+          // 백엔드 API 직접 호출하여 사용자 삭제
+          cy.request({
+            method: 'DELETE',
+            url: `http://localhost:8080/users/${createdUserId}`,
+            failOnStatusCode: false // 삭제 실패 시에도 테스트 중단하지 않음
+          }).then((response) => {
+            if (response.status === 200) {
+              cy.log(`사용자 ID ${createdUserId} 삭제 성공`);
+            } else {
+              cy.log(`사용자 ID ${createdUserId} 삭제 실패: ${response.status}`);
+            }
+          });
+        } else if (!createdUserId) {
+          cy.log('사용자 ID를 추출할 수 없어 삭제를 건너뜁니다.');
+        }
+      }
+    });
 
     // 회원가입 후 로그인 페이지로 돌아갔는지 확인
     cy.url().should('include', '/logIn');


### PR DESCRIPTION
### 변경 내용
- 회원가입 E2E 테스트에서 생성된 사용자의 ID를 자동으로 조회하고 삭제하는 로직 추가
- 다양한 응답 구조(id, userId, data.id, result.id)에 대응하도록 사용자 ID 추출 로직 구현
- 사용자 ID가 응답에 포함되지 않는 경우, 이메일 기반 사용자 조회 API 호출로 ID 획득
- 테스트 완료 후 생성된 테스트 데이터 자동 삭제로 데이터베이스 오염 방지

### 추가 사항
- favcolor 입력 셀렉터 오타 수정 (`input[name="favcolor']` → `input[name="favcolor"]`)

### 기대 효과
- E2E 테스트 실행 후 데이터 정리 자동화
- 동일 이메일 테스트 시 중복 회원가입 오류 방지
- 테스트 환경 데이터 일관성 유지
