### PR TITLE
[test] feat: Cypress 커맨드에 임의 계정 로그인 및 로그아웃 기능 추가

### DIFF
--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -1,11 +1,30 @@
 Cypress.Commands.add('login', () => {
-    cy.visit('/');
-    cy.url().should('include', '/logIn');
+  cy.visit('/');
+  cy.url().should('include', '/logIn');
 
-    cy.get('input[type="email"]').type(Cypress.env('TEST_EMAIL'));
-    cy.get('input[type="password"]').type(Cypress.env('TEST_PASSWORD'));
+  cy.get('input[type="email"]').type(Cypress.env('TEST_EMAIL'));
+  cy.get('input[type="password"]').type(Cypress.env('TEST_PASSWORD'));
 
-    cy.get('button[type="button"]').click();
+  cy.get('button[type="button"]').click();
 
-    cy.url().should('include', '/main');
-})
+  cy.url().should('include', '/main');
+});
+
+// 임의의 계정으로 로그인
+Cypress.Commands.add('loginWith', (email, password) => {
+  cy.visit('/');
+  cy.url().should('include', '/logIn');
+
+  cy.get('input[type="email"]').clear().type(email);
+  cy.get('input[type="password"]').clear().type(password);
+
+  cy.get('button[type="button"]').click();
+
+  cy.url().should('include', '/main');
+});
+
+// 세션 초기화 후 로그인 페이지로 이동
+Cypress.Commands.add('logout', () => {
+  cy.get('i.material-icons.logout-icon').contains('logout').click();
+  cy.url().should('include', '/logIn');
+});


### PR DESCRIPTION
## 변경 사항
- `loginWith(email, password)`  
  - 인자로 전달된 계정 정보로 로그인 수행
  - 입력 필드 초기화 후 새 값 입력
- `logout()`  
  - 로그아웃 아이콘 클릭 후 로그인 페이지 이동 확인
- 기존 `login` 커맨드 로직 정리 (코드 스타일 통일)