### PR TITLE
[test] fix: 회원 정보 수정 테스트에서 데이터 복원 입력값 수정

### DIFF
--- a/frontend/cypress/e2e/user.cy.js
+++ b/frontend/cypress/e2e/user.cy.js
@@ -188,8 +188,8 @@ describe('사용자 관련 시나리오', () => {
     cy.url().should('include', '/userInfoEdit');
 
     cy.get('input');
-    cy.get('input[placeholder="First Name"]').clear().type('FirstName');
-    cy.get('input[placeholder="Last Name"]').clear().type('LastName');
+    cy.get('input[placeholder="First Name"]').clear().type('test1');
+    cy.get('input[placeholder="Last Name"]').clear().type('test1');
     cy.get('input[placeholder="Email Address"]').clear().type('test');
     cy.get('input[placeholder="Password"]').clear().type('test');
     cy.get('input#favcolor')


### PR DESCRIPTION
## 개요
향후 초대 기능과 같은 **계정 간 상호작용 시나리오**를 테스트하기 위해,  
회원 정보 수정 테스트의 데이터 복원 단계에서 사용자명을 `test1`로 변경했습니다.

## 변경 사항
- 회원 정보 수정 테스트(`user.cy.js`) 복원 단계
  - `First Name` → `test1`
  - `Last Name` → `test1`
- `test1`, `test2` 두 계정을 분리해 테스트 시나리오 간 충돌을 방지

## 목적
- 초대 기능 테스트 예시  
  - `test1`이 `test2`를 초대  
  - `test2` 계정에서 초대 알림 수신 여부 확인  
- 계정 간 상호작용을 안정적으로 테스트할 수 있는 환경 구성