### PR TITLE
[test] feat: 팀 생성 및 사용자 초대 E2E 테스트 추가

### DIFF
--- a/frontend/cypress/e2e/team.cy.js
+++ b/frontend/cypress/e2e/team.cy.js
@@ -1,0 +1,97 @@
+import '../support/commands';
+
+describe('팀 관리 E2E 테스트', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  describe('팀 생성', () => {
+    it('새로운 팀을 성공적으로 생성할 수 있어야 한다', () => {
+      const teamName = `테스트팀_${Date.now()}`;
+
+      // 팀 생성 버튼 클릭
+      cy.get('[data-bs-target="#createGroup-form"]').click();
+
+      // 팀 이름 입력
+      cy.get('#createGroup-form input[placeholder="Group Name"]').type(
+        teamName
+      );
+
+      // 팀 생성 완료 후 페이지 새로고침 또는 API 응답 대기
+      cy.intercept('GET', '/members/userTeamList/*').as('getTeams');
+
+      // 팀 생성 확인 버튼 클릭
+      cy.get('#createGroup-form .modal-footer button')
+        .contains('Create')
+        .click();
+
+      // 모달이 닫히는지 확인
+      cy.get('#createGroup-form').should('not.be.visible');
+
+      // team list 안에 팀명이 나타날 때까지 기다린 후 확인
+      cy.get('ul.team-list-scroll')
+        .should('exist')
+        .within(() => {
+          cy.contains('a.list-group-item.list-group-item-action', teamName, {
+            timeout: 1000,
+          })
+            .scrollIntoView()
+            .should('be.visible');
+        });
+    });
+  });
+
+  describe('사용자 초대', () => {
+    it('기존 팀에 사용자를 초대할 수 있어야 한다 (초대 알림 확인 포함)', () => {
+      const inviteeEmail = Cypress.env('TEST_EMAIL2') || 'test2';
+      const inviteePassword = Cypress.env('TEST_PASSWORD2') || 'test2';
+
+      // 첫 번째 팀 선택 (좌측 팀 리스트) 및 team_name 추출 → alias 저장
+      cy.get('.team-list-scroll .list-group-item')
+        .first()
+        .then(($team) => {
+          const name = $team.text().trim();
+          cy.wrap(name).as('selectedTeamName');
+          cy.wrap($team).click();
+        });
+
+      // 멤버 추가 버튼 클릭
+      cy.get('[data-bs-target="#inviteUser-form"]').click();
+
+      // 사용자 검색
+      const searchUser = inviteeEmail;
+      cy.get('#inviteUser-form input[placeholder="Search"]').type(searchUser);
+      cy.get('#inviteUser-form #searchBtn').click();
+
+      // 검색된 사용자 선택
+      cy.get('#inviteUser-form .list-group-item').first().click();
+
+      // 초대 버튼 클릭
+      cy.get('#inviteUser-form .modal-footer button')
+        .contains('invite')
+        .click();
+
+      // 모달이 닫히는지 확인
+      cy.get('#inviteUser-form').should('not.be.visible');
+
+      // 초대 보낸 후, 로그아웃 후 test2 계정으로 로그인
+      cy.logout();
+      cy.loginWith(inviteeEmail, inviteePassword);
+
+      // 헤더 알림 드롭다운 열기 (alarm 아이콘)
+      cy.get('nav .dropdown a.nav-link[data-bs-toggle="dropdown"]').click();
+
+      // 초대 알림 목록에서 inviter(first_name)가 'test1'이고 team_name이 선택한 팀명과 일치하는 항목 존재 확인
+      cy.get('@selectedTeamName').then((teamName) => {
+        cy.get('ul.dropdown-menu ul.notification-list li.list-group-item')
+          .filter((i, el) => {
+            const $el = Cypress.$(el);
+            const firstName = $el.find('strong').eq(0).text().trim();
+            const invitedTeamName = $el.find('strong').eq(1).text().trim();
+            return firstName === 'test1' && invitedTeamName === teamName;
+          })
+          .should('have.length.at.least', 1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 개요
Cypress를 이용해 팀 관리 기능에 대한 E2E 테스트를 작성했습니다.  
팀 생성부터 초대 수락 확인까지의 주요 시나리오를 자동화했습니다.

## 변경 사항
- **팀 생성 시나리오**
  - 새로운 팀 생성 버튼 클릭 → 팀 이름 입력 → 생성 버튼 클릭
  - 모달 닫힘 및 팀 목록에서 생성된 팀명 확인
- **사용자 초대 시나리오**
  - 기존 팀 선택 후 사용자 검색 및 초대
  - 로그아웃 후 초대한 계정으로 로그인하여 초대 알림 수신 여부 확인
  - 초대 알림은 `first_name = test1` && `team_name = 선택한 팀명` 조건으로 검증
