### PR TITLE
[cicd] refactor: Dockerfile 멀티 스테이지 빌드 적용 및 CI 워크플로우 단순화

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,31 +12,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      # ----------- FRONTEND -----------
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: npm install
-
-      - name: Build frontend
-        working-directory: ./frontend
-        run: npm run build
-
-      # ----------- BACKEND -----------
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Build backend with Gradle
-        working-directory: ./backend
-        run: ./gradlew clean build -x test
-
       # ----------- DOCKER -----------
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,12 @@
-FROM eclipse-temurin:17-jdk
+# build stage
+FROM gradle:8.7.0-jdk17 AS build
+WORKDIR /workspace
+COPY . .
+RUN chmod +x gradlew
+RUN ./gradlew clean build -x test
+
+# runtime stage
+FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY build/libs/*.jar app.jar
+COPY --from=build /workspace/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
# [cicd] Docker 멀티 스테이지 빌드 적용 및 CI 워크플로우 단순화

## 목적
- 러너에서의 **중복 빌드 제거** 및 CI 시간 단축, 비용 절감
- 빌드 아티팩트 생성 책임을 **Dockerfile**로 일원화하여 재현성과 이식성 향상

## 주요 변경 사항
1. **backend/Dockerfile**
   - Gradle 기반 **멀티 스테이지 빌드** 도입
     - `build` 스테이지: `gradle:8.7.0-jdk17` 이미지에서 `./gradlew clean build -x test`
     - `runtime` 스테이지: `eclipse-temurin:17-jre`에서 `COPY --from=build /workspace/build/libs/*.jar app.jar`
   - 런타임 이미지를 JRE로 축소하여 이미지 크기 감소

2. **.github/workflows/ci-cd.yml**
   - 러너 내 **프론트/백의 로컬 빌드 단계 제거**
     - Node 설치 → `npm run build` 삭제
     - JDK 설치 → Gradle 빌드 삭제
   - Docker 빌드 시에만 빌드가 수행되도록 간소화

## 배경 및 의사결정
- 이전에는 프론트가 **워크플로우에서 한 번**, Docker 빌드에서 **한 번 더** 빌드되어 **이중 빌드**가 발생했습니다.
- “**Dockerfile 내부에서만 빌드**” 전략으로 통일하여 CI 파이프라인을 단순화했습니다.

## 기대 효과
- CI 시간 단축 및 러너 리소스 사용량 감소
- 환경 차이에 따른 빌드 불일치 최소화
- 더 작은 런타임 이미지로 배포/전송 시간 단축

## 호환성/영향 범위
- 배포 방식은 동일합니다. 빌드 책임만 Docker로 이동했습니다.
- 애플리케이션 코드 변경 없음