### PR TITLE
[ci] refactor: 워크플로우를 수동 실행 방식으로 전환 (태그 기반 버저닝 준비)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,8 +1,9 @@
 name: CI/CD Monorepo Vue + Spring Boot
 
 on:
-  push:
-    branches: [ main ]
+  # push:
+    # branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## 목적
- 기존: `main` 브랜치 push 시 자동 실행 → 무조건 CI/CD 파이프라인 수행  
- 변경: **수동 실행(dispatch)** 으로 전환하여, 배포 시점을 태그 발행과 연동할 수 있도록 준비  
- 최종 목표: **태그 기반 버저닝 + 자동 배포** 전략 도입

## 주요 변경 사항
- `.github/workflows/ci-cd.yml`
  - `on: push` 트리거 제거
  - `workflow_dispatch` 로 변경 → 필요 시점에만 직접 실행 가능
- 배포 트리거를 **버전 태그 생성 → 워크플로우 실행** 방식으로 바꿀 예정

## 배경
- main 브랜치에 코드가 병합될 때마다 배포되는 방식은,  
  - 불필요한 중간 커밋까지 배포되는 문제  
  - 안정성 검증 후 원하는 시점에 릴리스를 배포하기 어렵다는 문제  
  가 존재했습니다.

## 기대 효과
- 불필요한 자동 배포 제거 → 배포 제어권 확보
- 추후 태그 발행(버전 릴리스) 시점에만 안정적으로 배포 가능
- CI/CD 파이프라인 단순화 및 관리 용이성 향상
