### PR TITLE
[ci] feat: 백엔드 전용 자동 버저닝(be-v*) 워크플로우 추가

### DIFF
--- a/.github/workflows/be-autotag-on-main.yml
+++ b/.github/workflows/be-autotag-on-main.yml
@@ -1,0 +1,73 @@
+name: BE AutoTag on main
+
+on:
+  push:
+    branches: ["main"]              
+    paths:
+      - "backend/**"               # backend 디렉터리 변경이 있을 때만
+
+permissions:
+  contents: write
+
+jobs:
+  be-autotag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Find last BE tag
+        id: last
+        run: |
+          LAST_TAG=$(git tag --list "be-v*" --sort=-v:refname | head -n1 || true)
+          echo "last=$LAST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Commit range since last BE tag
+        id: range
+        run: |
+          if [ -z "${{ steps.last.outputs.last }}" ]; then
+            RANGE="$(git rev-list --max-parents=0 HEAD | tail -n1)..HEAD"
+          else
+            RANGE="${{ steps.last.outputs.last }}..HEAD"
+          fi
+          echo "range=$RANGE" >> $GITHUB_OUTPUT
+
+      - name: Decide bump by Conventional Commits
+        id: bump
+        run: |
+          RANGE="${{ steps.range.outputs.range }}"
+          COMMITS=$(git log --pretty=format:"%s%n%b" $RANGE -- backend || true)
+
+          MAJOR=0; MINOR=0; PATCH=0
+          echo "$COMMITS" | grep -qiE "(BREAKING CHANGE|!:)" && MAJOR=1
+          [ $MAJOR -eq 0 ] && echo "$COMMITS" | grep -qiE "(^|[^a-z])feat(\(.+\))?: " && MINOR=1
+          [ $MAJOR -eq 0 ] && [ $MINOR -eq 0 ] && echo "$COMMITS" | grep -qiE "(^|[^a-z])(fix|perf|refactor)(\(.+\))?: " && PATCH=1
+
+          if [ $MAJOR -eq 0 ] && [ $MINOR -eq 0 ] && [ $PATCH -eq 0 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          LAST="${{ steps.last.outputs.last }}"
+          [ -z "$LAST" ] && BASE="0.0.0" || BASE="${LAST#be-v}"
+
+          IFS='.' read -r MA MI PA <<< "$BASE"
+          if [ $MAJOR -eq 1 ]; then
+            MA=$((MA+1)); MI=0; PA=0
+          elif [ $MINOR -eq 1 ]; then
+            MI=$((MI+1)); PA=0
+          else
+            PA=$((PA+1))
+          fi
+
+          NEW="be-v${MA}.${MI}.${PA}"
+          echo "new=$NEW" >> $GITHUB_OUTPUT
+
+      - name: Create BE tag
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          NEW="${{ steps.bump.outputs.new }}"
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git tag "$NEW"
+          git push origin "$NEW"


### PR DESCRIPTION
## 목적
- 백엔드 변경 사항이 `main` 브랜치에 병합될 때마다 자동으로 **버전 태그(be-v*)** 생성
- **Conventional Commits** 규칙(`feat`, `fix`, `BREAKING CHANGE`) 기반으로 버전 승급
  - `BREAKING CHANGE` → Major
  - `feat` → Minor
  - `fix`, `refactor`, `perf` → Patch
- 태그 기반 배포 전략에 맞춘 **자동화된 버저닝 체계** 마련

## 주요 변경 사항
- `.github/workflows/be-autotag-on-main.yml` 추가
  - `backend/**` 경로 변경 시에만 워크플로우 실행
  - 기존 `be-v*` 태그 조회 → 이후 커밋 메시지 분석
  - Conventional Commits 규칙 기반으로 새 버전 결정
  - 새로운 `be-v*` 태그 생성 후 원격 저장소에 push

## 배경
- 프론트엔드(`fe-v*`) 자동 버저닝 워크플로우에 이어,
- 백엔드도 동일한 방식으로 자동 태그 생성이 필요
- CI/CD 자동 배포를 **태그 기반 버저닝**으로 전환하기 위한 단계

## 기대 효과
- 백엔드 버저닝 프로세스 자동화 → 수동 태깅 불필요
- 프론트/백의 버전 태그 규칙 통일(`fe-v*`, `be-v*`)
- 태그 기반 배포 파이프라인 연동 준비 완료