### PR TITLE
[ci] feat: 프론트엔드 태그 기반 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/fe-deploy-on-tag.yml
+++ b/.github/workflows/fe-deploy-on-tag.yml
@@ -1,0 +1,77 @@
+name: FE Deploy on Tag
+
+on:
+  push:
+    tags: ["fe-v*"]                        # 프론트 버전 태그가 푸시되면 실행
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/group-diary-frontend
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: frontend-deploy               # 프론트 배포는 직렬로 처리
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4          # 빌드 컨텍스트용 체크아웃
+
+      - name: Extract version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV  # fe-vX.Y.Z
+
+      # ----------- DOCKER -----------
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub           # DockerHub 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build & Push FE image        # 버전 태그 및 latest-fe 보조 태그 푸시
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:latest-fe
+          no-cache: true
+
+      # ----------- DEPLOY -----------
+      - name: Set up SSH                   # 배포 서버 접속 준비
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+      
+      - name: Create deploy directory on EC2
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
+          ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} \
+          "mkdir -p /home/ubuntu/group-diary"
+
+      - name: Upload docker-compose.yml    # 서버에 compose 파일 동기화
+        run: |
+          scp -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
+            ./docker-compose.yml ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/home/ubuntu/group-diary/
+
+      - name: Deploy frontend via SSH
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
+          ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} "
+            set -e
+            docker pull ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            IMAGE=${{ env.IMAGE_NAME }}:${{ env.VERSION }} docker compose -f /home/ubuntu/group-diary/docker-compose.yml up -d frontend
+          "
+
+      - name: Docker clean after deploy
+        run: |
+          docker image prune -af
+          docker container prune -f
+          docker builder prune -af


### PR DESCRIPTION
## 목적
- `fe-v*` 태그가 푸시될 때 프론트엔드 이미지를 빌드·푸시하고 EC2에 배포하도록 자동화했습니다.
- 태그 기반 버저닝/배포 플로우 정착을 위한 단계로, 수동 개입 없이 **버전 태그 = 배포 단위**를 보장합니다.

## 주요 변경 사항
- `.github/workflows/fe-deploy-on-tag.yml` 추가
  - 트리거: `on.push.tags: ["fe-v*"]`
  - 이미지 이름: `${{ secrets.DOCKER_USERNAME }}/group-diary-frontend`
  - 버전 추출: `GITHUB_REF`에서 `fe-vX.Y.Z` 추출 후 `env.VERSION` 설정
  - DockerHub 로그인 → `docker/build-push-action`으로 이미지 빌드/푸시
    - 태그: `${IMAGE_NAME}:${VERSION}`, `${IMAGE_NAME}:latest-fe`
  - SSH로 배포 서버 접속 후 `docker compose up -d frontend` 실행
  - 선택: 배포 후 `docker image/container/builder prune`로 디스크 정리

## 배경
- 기존 자동화는 브랜치 기반으로 배포되어 배포 시점/대상 제어가 어려웠습니다.
- 태그 기반으로 전환하여 **명시적 릴리스(태그)만 배포**되도록 표준화했습니다.
- FE/BE 각각 독립 버저닝(`fe-v*`, `be-v*`) 전략과 연동하기 위한 구성입니다.

## 기대 효과
- 태그 발행만으로 일관된 배포 실행
- 운영 서버에서 항상 최신 프론트를 가리키는 `latest-fe` 보조 태그 제공
- CI 러너 내 중복 빌드 제거 및 파이프라인 단순화(빌드·배포 흐름 명확화)

## 안전장치
- `concurrency.group: frontend-deploy`로 프론트 배포 직렬화 → 동시 배포 충돌 방지
- 원격 쉘 내 `set -e`로 중간 실패 시 즉시 종료
- 배포 디렉터리 미존재 대비 `mkdir -p` 수행