### PR TITLE
[ci] feat: 백엔드 태그 기반 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/be-deploy-on-tag.yml
+++ b/.github/workflows/be-deploy-on-tag.yml
@@ -1,0 +1,70 @@
+name: BE Deploy on Tag
+
+on:
+  push:
+    tags: ["be-v*"]                        # 백엔드 버전 태그가 푸시되면 실행
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/group-diary-backend
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: backend-deploy                # 백엔드 배포는 직렬로 처리
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV  # be-vX.Y.Z
+
+      # ----------- DOCKER -----------
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub           
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build & Push BE image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:latest-be
+          no-cache: true
+
+      - name: Set up SSH                   # 배포 서버 접속 준비
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Create deploy directory on EC2
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
+          ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} \
+          "mkdir -p /home/ubuntu/group-diary"
+
+      - name: Upload docker-compose.yml    # 서버에 compose 파일 동기화
+        run: |
+          scp -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
+            ./docker-compose.yml ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/home/ubuntu/group-diary/
+
+      - name: Deploy backend via SSH
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
+          ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} "
+            set -e
+            docker pull ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            IMAGE=${{ env.IMAGE_NAME }}:${{ env.VERSION }} docker compose -f /home/ubuntu/group-diary/docker-compose.yml up -d backend
+          "


### PR DESCRIPTION
## 목적
- `be-v*` 태그가 푸시될 때 백엔드 이미지를 빌드·푸시하고 EC2에 자동 배포하도록 구성했습니다.
- 태그 기반 버저닝/배포 플로우 정착을 통해 **버전 태그 = 배포 단위**를 보장합니다.

## 주요 변경 사항
- `.github/workflows/be-deploy-on-tag.yml` 추가
  - 트리거: `on.push.tags: ["be-v*"]`
  - 이미지 이름: `${{ secrets.DOCKER_USERNAME }}/group-diary-backend`
  - 버전 추출: `GITHUB_REF`에서 `be-vX.Y.Z`를 파싱하여 `env.VERSION` 설정
  - DockerHub 로그인 → `docker/build-push-action`으로 이미지 빌드/푸시
    - 태그: `${IMAGE_NAME}:${VERSION}`, `${IMAGE_NAME}:latest-be`
  - SSH 접속 후 `docker compose -f /home/ubuntu/group-diary/docker-compose.yml up -d backend` 실행
  - 배포 디렉터리 미존재 대비 `mkdir -p` 및 `docker-compose.yml` 동기화 포함
- `concurrency.group: backend-deploy`로 백엔드 배포 직렬 처리

## 배경
- 브랜치 기반 자동 배포는 배포 시점/대상 제어가 어렵습니다.
- FE(`fe-v*`)와 동일한 전략으로 BE도 **태그 기반 버저닝/배포**를 도입하여 릴리스 단위를 명확히 했습니다.

## 기대 효과
- 태그 발행만으로 일관된 백엔드 배포 수행
- 운영 서버에서 최신 백엔드를 지칭하는 `latest-be` 보조 태그 제공
- FE/BE 분리된 버저닝으로 서비스별 독립 릴리스 가능

## 안전장치
- `concurrency`를 통한 동시 배포 충돌 방지
- 원격 쉘 내 `set -e`로 실패 시 즉시 중단
- 디렉터리 생성(`mkdir -p`)로 초기 서버 환경에서도 실패 최소화