### PR TITLE
[ci] refactor: docker-compose.yml 이미지 태그를 환경변수 기반으로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   frontend:
-    image: jihyun923/group-diary-frontend:latest
+    image: ${IMAGE:-${DOCKER_USER:-jihyun923}/group-diary-frontend:latest-fe}
     container_name: frontend
     ports:
       - "80:80"
@@ -9,7 +9,7 @@ services:
       - backend
 
   backend:
-    image: jihyun923/group-diary-backend:latest
+    image: ${IMAGE:-${DOCKER_USER:-jihyun923}/group-diary-backend:latest-be}
     container_name: backend
     ports:
       - "8080:8080"


### PR DESCRIPTION
## 목적
- 기존에는 `docker-compose.yml`에서 이미지 태그를 고정값(`latest`)으로 지정하고 있었습니다.
- 이를 `IMAGE`, `DOCKER_USER` 환경변수를 통해 **유연하게 덮어쓸 수 있도록 개선**했습니다.
- 기본값은 `latest-fe`(frontend), `latest-be`(backend)를 사용하여 서비스별 최신 버전을 명확히 구분했습니다.

## 주요 변경 사항
- `docker-compose.yml`
  - frontend
    - `jihyun923/group-diary-frontend:latest` → `${IMAGE:-${DOCKER_USER:-jihyun923}/group-diary-frontend:latest-fe}`
  - backend
    - `jihyun923/group-diary-backend:latest` → `${IMAGE:-${DOCKER_USER:-jihyun923}/group-diary-backend:latest-be}`

## 배경
- CI/CD 파이프라인에서 태그 기반 버저닝(`fe-v*`, `be-v*`)을 도입함에 따라,  
  `docker-compose.yml`에서도 특정 태그를 쉽게 주입할 수 있는 구조가 필요했습니다.
- `IMAGE` 변수를 활용하면 배포 시점에 원하는 버전(`fe-vX.Y.Z`, `be-vX.Y.Z`)을 지정할 수 있고,  
  지정하지 않으면 자동으로 최신(`latest-fe`, `latest-be`)이 사용됩니다.

## 기대 효과
- 배포 파이프라인에서 버전 태그 지정이 간단해짐  
  ```bash
  IMAGE=jihyun923/group-diary-frontend:fe-v1.2.3 docker compose up -d frontend