### PR TITLE
[ci] feat: DRY_RUN 플래그 추가로 프론트/백엔드 배포 단계 스킵 지원

### DIFF
--- a/.github/workflows/be-deploy-on-tag.yml
+++ b/.github/workflows/be-deploy-on-tag.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/group-diary-backend
+  DRY_RUN: ${{ vars.DRY_RUN }}   # 리포지토리 Variables에 DRY_RUN=true로 넣으면 배포 스킵
 
 jobs:
   deploy:
@@ -61,6 +62,7 @@ jobs:
             ./docker-compose.yml ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/home/ubuntu/group-diary/
 
       - name: Deploy backend via SSH
+        if: env.DRY_RUN != 'true'   # DRY_RUN이면 배포 단계 건너뜀
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
           ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} "

--- a/.github/workflows/fe-deploy-on-tag.yml
+++ b/.github/workflows/fe-deploy-on-tag.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/group-diary-frontend
+  DRY_RUN: ${{ vars.DRY_RUN }}   # 리포지토리 Variables에 DRY_RUN=true로 넣으면 배포 스킵
 
 jobs:
   deploy:
@@ -62,6 +63,7 @@ jobs:
             ./docker-compose.yml ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/home/ubuntu/group-diary/
 
       - name: Deploy frontend via SSH
+        if: env.DRY_RUN != 'true'   # DRY_RUN이면 배포 단계 건너뜀
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no \
           ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} "


### PR DESCRIPTION
### 개요
- 프론트엔드(fe-deploy-on-tag.yml), 백엔드(be-deploy-on-tag.yml) 배포 워크플로우에 DRY_RUN 변수를 추가했습니다.
- DRY_RUN 변수를 true로 설정하면 Docker 빌드/푸시까지만 수행하고, EC2 서버 배포 단계(SSH/compose up)는 스킵합니다.

### 주요 변경 사항
- `env:` 블록에 `DRY_RUN: ${{ vars.DRY_RUN }}` 추가
- Deploy via SSH 단계에 `if: env.DRY_RUN != 'true'` 조건 추가
- 리포지토리 Variables에 `DRY_RUN` 값을 true/false로 설정해 테스트/실배포를 전환 가능

### 기대 효과
- 실제 서비스 중단 없이 파이프라인 전체를 안전하게 검증 가능
- 빌드/푸시 단계까지 정상 동작 여부 확인 후, 필요 시 DRY_RUN=false로 실배포 수행

### 테스트 방법
1. 리포지토리 Settings → Variables → DRY_RUN=true 설정
2. 프론트/백엔드 각각 작은 변경(PR 머지) → 빌드/푸시까지만 동작 확인
3. DRY_RUN=false로 변경 후 재배포 → EC2 서버 배포까지 진행되는지 확인
