### PR TITLE
ci: FE/BE autotag 워크플로우에서 GITHUB_TOKEN → PAT으로 교체해 on:push(tags) 트리거 정상화

### DIFF
--- a/.github/workflows/be-autotag-on-main.yml
+++ b/.github/workflows/be-autotag-on-main.yml
@@ -63,11 +63,23 @@ jobs:
           NEW="be-v${MA}.${MI}.${PA}"
           echo "new=$NEW" >> $GITHUB_OUTPUT
 
-      - name: Create BE tag
+#      - name: Create BE tag
+#        if: steps.bump.outputs.skip != 'true'
+#        run: |
+#          NEW="${{ steps.bump.outputs.new }}"
+#          git config user.name "github-actions"
+#          git config user.email "github-actions@users.noreply.github.com"
+#          git tag "$NEW"
+#          git push origin "$NEW"
+
+      - name: Create BE tag (with PAT to trigger downstream workflows)
         if: steps.bump.outputs.skip != 'true'
+        env:
+          PAT: ${{ secrets.ACTIONS_PAT }}
+          REPO: ${{ github.repository }}
         run: |
           NEW="${{ steps.bump.outputs.new }}"
-          git config user.name "github-actions"
-          git config user.email "github-actions@users.noreply.github.com"
+          git config user.name "ci-bot"
+          git config user.email "ci-bot@users.noreply.github.com"
           git tag "$NEW"
-          git push origin "$NEW"
+          git push https://$PAT@github.com/$REPO "$NEW"

--- a/.github/workflows/fe-autotag-on-main.yml
+++ b/.github/workflows/fe-autotag-on-main.yml
@@ -71,11 +71,24 @@ jobs:
           echo "new=$NEW" >> $GITHUB_OUTPUT
 
       # 새 프론트 버전 태그를 만들고 푸시
-      - name: Create FE tag
+#      - name: Create FE tag
+#        if: steps.bump.outputs.skip != 'true'
+#        run: |
+#          NEW="${{ steps.bump.outputs.new }}"
+#          git config user.name "github-actions"
+#          git config user.email "github-actions@users.noreply.github.com"
+#          git tag "$NEW"
+#          git push origin "$NEW"
+
+      # GITHUB_TOKEN 대신 PAT로 태그 푸시 → on:push(tags) 트리거 가능
+      - name: Create FE tag (with PAT to trigger downstream workflows)
         if: steps.bump.outputs.skip != 'true'
+        env:
+          PAT: ${{ secrets.ACTIONS_PAT }}
+          REPO: ${{ github.repository }}
         run: |
           NEW="${{ steps.bump.outputs.new }}"
-          git config user.name "github-actions"
-          git config user.email "github-actions@users.noreply.github.com"
+          git config user.name "ci-bot"
+          git config user.email "ci-bot@users.noreply.github.com"
           git tag "$NEW"
-          git push origin "$NEW"
+          git push https://$PAT@github.com/$REPO "$NEW"


### PR DESCRIPTION
## 배경
- GITHUB_TOKEN으로 푸시한 태그는 보안상의 이유로 다른 워크플로우를 트리거하지 않습니다.
- fe/be 자동 태깅 후 `on: push: tags` 기반 배포 워크플로우가 실행되지 않는 문제가 있어, 태그 푸시에 PAT을 사용하도록 수정했습니다.

## 주요 변경
- `.github/workflows/fe-autotag-on-main.yml`, `.github/workflows/be-autotag-on-main.yml`
  - 태그 생성 스텝을 **PAT 푸시**로 교체: `git push https://$PAT@github.com/$REPO "$NEW"`
  - PAT은 리포지토리 시크릿 `ACTIONS_PAT`로 주입합니다.
  - 주석 처리했던 기존 GITHUB_TOKEN 푸시 스텝을 대체했습니다.

## 보안/권한
- PAT 권한: 최소 권한 원칙에 따라 **Contents: Read & write**만 부여했습니다.
- 저장 위치: 리포지토리 **Secrets**(`ACTIONS_PAT`)에 보관합니다.
- 조직/리포 권한 정책 상 fine-grained PAT를 권장합니다.

## 실행/테스트 방법
1. 기본 브랜치(`main`)에 **배포 워크플로우 파일(fe/be deploy on tag)** 가 존재하는지 확인합니다.
2. 테스트 브랜치에서 작은 변경을 머지해 자동 태깅을 유도합니다.
3. 태그가 생성되면, **`FE/BE Deploy on Tag`** 워크플로우가 실행되는지 확인합니다.
   - 리포 태그 탭에 `fe-v*`/`be-v*` 생성 확인
   - Actions 탭에서 `on: push: tags` 기반 워크플로우 실행 확인
4. 배포 영향 없이 검증하려면 `DRY_RUN=true`로 설정한 뒤 확인합니다.

## 영향 범위
- 자동 태깅 후 태그 기반 워크플로우가 정상적으로 트리거됩니다.
- 애플리케이션 코드에는 변경이 없습니다.